### PR TITLE
Qt5/0.8.0: debian dependencies / QT5LIBDIR

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 9), qt5-qmake, qtbase5-dev, qtmultimedia5-dev,
                libxcb1-dev, libx11-xcb-dev, libxcb-ewmh-dev, make, g++,
                libx11-dev, libxrender-dev, libxcomposite-dev, libxdamage-dev,
                libxcb-icccm4-dev, libxcb-damage0-dev, libxcb-util0-dev,
-               libqt5x11extras5-dev
+               libqt5x11extras5-dev, qttools5-dev-tools
 Standards-Version: 3.9.5
 Homepage: https://github.com/pcbsd/lumina
 

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,8 @@ Maintainer: Christopher Roy Bratusek <nano@jpberlin.de>
 Build-Depends: debhelper (>= 9), qt5-qmake, qtbase5-dev, qtmultimedia5-dev,
                libxcb1-dev, libx11-xcb-dev, libxcb-ewmh-dev, make, g++,
                libx11-dev, libxrender-dev, libxcomposite-dev, libxdamage-dev,
-               libxcb-icccm4-dev, libxcb-damage0-dev, libxcb-util0-dev
+               libxcb-icccm4-dev, libxcb-damage0-dev, libxcb-util0-dev,
+               libqt5x11extras5-dev
 Standards-Version: 3.9.5
 Homepage: https://github.com/pcbsd/lumina
 

--- a/lumina-config/lumina-config.pro
+++ b/lumina-config/lumina-config.pro
@@ -40,7 +40,12 @@ INCLUDEPATH += ../libLumina $$PREFIX/include
 
 LIBS += -L../libLumina -L$$LIBPREFIX -lLuminaUtils
 
-LRELEASE = $$LIBPREFIX/qt5/bin/lrelease
+isEmpty(QT5LIBDIR) {
+ QT5LIBDIR = $$PREFIX/lib/qt5
+}
+
+LRELEASE = $$QT5LIBDIR/bin/lrelease
+
 
 QMAKE_LIBDIR	= ../libLumina
 DEPENDPATH	+= ../libLumina

--- a/lumina-desktop/lumina-desktop.pro
+++ b/lumina-desktop/lumina-desktop.pro
@@ -18,7 +18,12 @@ DEPENDPATH	+= ../libLumina
 
 TEMPLATE = app
 
-LRELEASE = $$LIBPREFIX/qt5/bin/lrelease
+isEmpty(QT5LIBDIR) {
+ QT5LIBDIR = $$PREFIX/lib/qt5
+}
+
+LRELEASE = $$QT5LIBDIR/bin/lrelease
+
 
 SOURCES += main.cpp \
 	WMProcess.cpp \

--- a/lumina-fm/lumina-fm.pro
+++ b/lumina-fm/lumina-fm.pro
@@ -40,11 +40,7 @@ INCLUDEPATH += ../libLumina $$PREFIX/include
 
 LIBS     += -L../libLumina -L$$LIBPREFIX -lLuminaUtils
 
-openbsd-g++4 {
-  LRELEASE = lrelease4
-} else {
-  LRELEASE = $$QT5LIBDIR/bin/lrelease
-}
+LRELEASE = $$QT5LIBDIR/bin/lrelease
 
 QMAKE_LIBDIR	= ../libLumina
 DEPENDPATH	+= ../libLumina

--- a/lumina-fm/lumina-fm.pro
+++ b/lumina-fm/lumina-fm.pro
@@ -12,10 +12,6 @@ isEmpty(LIBPREFIX) {
  LIBPREFIX = $$PREFIX/lib
 }
 
-isEmpty(QT5LIBDIR) {
- QT5LIBDIR = $$PREFIX/lib/qt5
-}
-
 TEMPLATE = app
 
 SOURCES += main.cpp \
@@ -39,6 +35,10 @@ FORMS    += MainUI.ui \
 INCLUDEPATH += ../libLumina $$PREFIX/include
 
 LIBS     += -L../libLumina -L$$LIBPREFIX -lLuminaUtils
+
+isEmpty(QT5LIBDIR) {
+ QT5LIBDIR = $$PREFIX/lib/qt5
+}
 
 LRELEASE = $$QT5LIBDIR/bin/lrelease
 

--- a/lumina-open/lumina-open.pro
+++ b/lumina-open/lumina-open.pro
@@ -28,7 +28,12 @@ LIBS     += -L../libLumina -L$$LIBPREFIX -lLuminaUtils
 QMAKE_LIBDIR	= ../libLumina
 DEPENDPATH	+= ../libLumina
 
-LRELEASE = $$LIBPREFIX/qt5/bin/lrelease
+isEmpty(QT5LIBDIR) {
+ QT5LIBDIR = $$PREFIX/lib/qt5
+}
+
+LRELEASE = $$QT5LIBDIR/bin/lrelease
+
 
 TRANSLATIONS =  i18n/lumina-open_af.ts \
                 i18n/lumina-open_ar.ts \

--- a/lumina-screenshot/lumina-screenshot.pro
+++ b/lumina-screenshot/lumina-screenshot.pro
@@ -25,8 +25,11 @@ INCLUDEPATH += ../libLumina $$PREFIX/include
 
 LIBS     += -L../libLumina -L$$LIBPREFIX -lLuminaUtils
 
-LRELEASE = $$LIBPREFIX/qt5/bin/lrelease
+isEmpty(QT5LIBDIR) {
+ QT5LIBDIR = $$PREFIX/lib/qt5
+}
 
+LRELEASE = $$QT5LIBDIR/bin/lrelease
 
 QMAKE_LIBDIR	= ../libLumina
 DEPENDPATH	+= ../libLumina

--- a/lumina-search/lumina-search.pro
+++ b/lumina-search/lumina-search.pro
@@ -27,7 +27,11 @@ INCLUDEPATH += ../libLumina $$PREFIX/include
 
 LIBS     += -L../libLumina -L$$LIBPREFIX -lLuminaUtils
 
-LRELEASE = $$LIBPREFIX/qt5/bin/lrelease
+isEmpty(QT5LIBDIR) {
+ QT5LIBDIR = $$PREFIX/lib/qt5
+}
+
+LRELEASE = $$QT5LIBDIR/bin/lrelease
 
 
 QMAKE_LIBDIR	= ../libLumina


### PR DESCRIPTION
add missing debian dependencies for
* libqt5x11extras5-dev
* qttools5-dev-tools

make use of QT5LIBDIR in all qmake files (I was assuming lrelease4 is for Qt4 on OpenBSD, but I'm not sure).