### PR TITLE
Also read /etc/luminaDesktop.conf.

### DIFF
--- a/libLumina/LuminaUtils.cpp
+++ b/libLumina/LuminaUtils.cpp
@@ -151,6 +151,8 @@ void LUtils::LoadSystemDefaults(bool skipOS){
   if(sysDefaults.isEmpty() && !skipOS){ sysDefaults = LUtils::readFile(LOS::AppPrefix()+"etc/luminaDesktop.conf.dist"); }
   if(sysDefaults.isEmpty() && !skipOS) { sysDefaults = LUtils::readFile(LOS::SysPrefix()+"etc/luminaDesktop.conf"); }
   if(sysDefaults.isEmpty() && !skipOS){ sysDefaults = LUtils::readFile(LOS::SysPrefix()+"etc/luminaDesktop.conf.dist"); }
+  if(sysDefaults.isEmpty() && !skipOS) { sysDefaults = LUtils::readFile("/etc/luminaDesktop.conf"); }
+  if(sysDefaults.isEmpty() && !skipOS){ sysDefaults = LUtils::readFile("/etc/luminaDesktop.conf.dist"); }
   if(sysDefaults.isEmpty()){ sysDefaults = LUtils::readFile(LOS::LuminaShare()+"luminaDesktop.conf"); }
   //Find the number of the left-most desktop screen
   QString screen = "0";


### PR DESCRIPTION
On (at least) OpenBSD, external packages are installed under /usr/local
but SYSCONFDIR is always /etc. That is external applications will
install their configuration file under /etc even if the binaries are
under /usr/local.