### PR TITLE
LuminaOS-Debian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ lumina-desktop (0.8.1.266-1nano) unstable; urgency=low
   * new GIT snapshot
     - add debian/patches/01-use-luminaos-debian.diff which uses
       LuminaOS-Debian instead of fallback LuminaOS-Linux
+    - add recommends on lxpolkit and qt5-configuration-tool
 
  -- Christopher Roy Bratusek <nano@jpberlin.de>  Fri, 23 Jan 2015 18:00:15 +0100
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,18 @@
+lumina-desktop (0.8.1.266-1nano) unstable; urgency=low
+
+  * new GIT snapshot
+    - add debian/patches/01-use-luminaos-debian.diff which uses
+      LuminaOS-Debian instead of fallback LuminaOS-Linux
+
+ -- Christopher Roy Bratusek <nano@jpberlin.de>  Fri, 23 Jan 2015 18:00:15 +0100
+
 lumina-desktop (0.8.0.244-nano) unstable; urgency=low
 
   * new GIT snapshot
-  * switch to qt5
-  * add dependecy on libxcb1-dev, libx11-xcb-dev, libxcb-ewmh-dev,
-    libxcb-icccm4-dev, libxcb-damage0-dev, libxcb-util0-dev
-  * drop dependency on libphonon-dev
+    - switch to qt5
+    - add dependecy on libxcb1-dev, libx11-xcb-dev, libxcb-ewmh-dev,
+      libxcb-icccm4-dev, libxcb-damage0-dev, libxcb-util0-dev
+    - drop dependency on libphonon-dev
  
  -- Christopher Roy Bratusek <nano@jpberlin.de>  Wed, 07 Jan 2015 17:06:35 +0100
 

--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,8 @@ Package: lumina-desktop
 Architecture: all
 Depends: libluminautils1, lumina-core, lumina-config, lumina-fm,
          lumina-open, lumina-screenshot, lumina-search
-Description: Lightweight Qt4-based desktop environment
+Recommends: lxpolkit, qt5-configuration-tool
+Description: Lightweight Qt5-based desktop environment
  Metapackage depending on all other lumina packages.
 
 Package: libluminautils1

--- a/debian/patches/01-use-luminaos-debian.diff
+++ b/debian/patches/01-use-luminaos-debian.diff
@@ -1,0 +1,13 @@
+diff --git a/libLumina/libLumina.pro b/libLumina/libLumina.pro
+index 0302b82..f58581e 100644
+--- a/libLumina/libLumina.pro
++++ b/libLumina/libLumina.pro
+@@ -36,7 +36,7 @@ SOURCES	+= LuminaXDG.cpp \
+ 	LuminaOS-FreeBSD.cpp \
+ 	LuminaOS-DragonFly.cpp \
+ 	LuminaOS-OpenBSD.cpp \
+-	LuminaOS-Linux.cpp \
++	LuminaOS-Debian.cpp \
+         LuminaOS-kFreeBSD.cpp
+ #       new OS support can be added here
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+01-use-luminaos-debian.diff

--- a/libLumina/LuminaOS-Debian.cpp
+++ b/libLumina/LuminaOS-Debian.cpp
@@ -1,0 +1,192 @@
+//===========================================
+//  Lumina-DE source code
+//  Copyright (c) 2014, Ken Moore
+//  Available under the 3-clause BSD license
+//  See the LICENSE file for full details
+//===========================================
+#ifdef __linux__
+#include <QDebug>
+#include "LuminaOS.h"
+#include <unistd.h>
+#include <stdio.h> // Needed for BUFSIZ
+
+//can't read xbrightness settings - assume invalid until set
+static int screenbrightness = -1;
+
+//OS-specific prefix(s)
+QString LOS::AppPrefix(){ return "/usr/"; } //Prefix for applications
+QString LOS::SysPrefix(){ return "/"; } //Prefix for system
+
+//OS-specific application shortcuts (*.desktop files)
+QString LOS::ControlPanelShortcut(){ return ""; } //system control panel
+QString LOS::AppStoreShortcut(){ return LOS::AppPrefix() + "/share/applications/synaptic.desktop"; } //graphical app/pkg manager
+QString LOS::QtConfigShortcut(){ return LOS::AppPrefix() + "/bin/qtconfig"; } //qtconfig binary (NOT *.desktop file)
+
+// ==== ExternalDevicePaths() ====
+QStringList LOS::ExternalDevicePaths(){
+  /* Returns: QStringList[<type>::::<filesystem>::::<path>]
+     Note: <type> = [USB, HDRIVE, DVD, SDCARD, UNKNOWN]
+     df is much better for this than mount, because it skips
+     all non-physical devices (like bind-mounts from schroot)
+     so they are not listed in lumina-fm */
+  QStringList devs = LUtils::getCmdOutput("df --output=source,fstype,target");
+  //Now check the output
+  for(int i=0; i<devs.length(); i++){
+    if(devs[i].startsWith("/dev/")){
+      QString type = devs[i].section(" on ",0,0);
+        type.remove("/dev/");
+      //Determine the type of hardware device based on the dev node
+      if(type.startsWith("sd")){ type = "HDRIVE"; }
+      else if(type.startsWith("sr")){ type="DVD"; }
+      else{ type = "UNKNOWN"; }
+      //Now put the device in the proper output format
+      devs[i] = type+"::::"+devs[i].section("(",1,1).section(",",0,0)+"::::"+devs[i].section(" on ",1,50).section("(",0,0).simplified();
+    }else{
+      //invalid device - remove it from the list
+      devs.removeAt(i);
+      i--;
+    }
+  }
+  return devs;
+}
+
+//Read screen brightness information
+int LOS::ScreenBrightness(){
+   //Returns: Screen Brightness as a percentage (0-100, with -1 for errors)
+  if(screenbrightness==-1){
+    if(QFile::exists(QDir::homePath()+"/.lumina/.currentxbrightness")){
+      int val = LUtils::readFile(QDir::homePath()+"/.lumina/.currentxbrightness").join("").simplified().toInt();
+      screenbrightness = val;
+    }
+  }
+  return screenbrightness;
+
+}
+
+//Set screen brightness
+void LOS::setScreenBrightness(int percent){
+  //ensure bounds
+  if(percent<0){percent=0;}
+  else if(percent>100){ percent=100; }
+  // float pf = percent/100.0; //convert to a decimel
+  //Run the command
+  QString cmd = "xbacklight -set %1";
+  // cmd = cmd.arg( QString::number( int(65535*pf) ) );
+  cmd = cmd.arg( QString::number( percent ) );
+  int ret = LUtils::runCmd(cmd);
+  //Save the result for later
+  if(ret!=0){ screenbrightness = -1; }
+  else{ screenbrightness = percent; }
+  LUtils::writeFile(QDir::homePath()+"/.lumina/.currentxbrightness", QStringList() << QString::number(screenbrightness), true);
+
+}
+
+//Read the current volume
+int LOS::audioVolume(){ //Returns: audio volume as a percentage (0-100, with -1 for errors)
+QString info = LUtils::getCmdOutput("amixer get Master").join("").simplified();;
+  int out = -1;
+  int start_position, end_position;
+  QString current_volume;
+  if(!info.isEmpty()){
+     start_position = info.indexOf("[");
+     start_position++;
+     end_position = info.indexOf("%");
+     current_volume = info.mid(start_position, end_position - start_position);
+     out = current_volume.toInt();
+  }
+  return out;
+
+
+}
+
+//Set the current volume
+void LOS::setAudioVolume(int percent){
+  if(percent<0){percent=0;}
+  else if(percent>100){percent=100;}
+  QString info = "amixer -c 0 sset Master,0 " + QString::number(percent) + "%";
+  if(!info.isEmpty()){
+    //Run Command
+    LUtils::runCmd(info);
+  }
+
+}
+
+//Change the current volume a set amount (+ or -)
+void LOS::changeAudioVolume(int percentdiff){
+  int old_volume = audioVolume();
+  int new_volume = old_volume + percentdiff;
+  if (new_volume < 0)
+      new_volume = 0;
+  if (new_volume > 100)
+      new_volume = 100;
+  qDebug() << "Setting new volume to: " << new_volume;
+  setAudioVolume(new_volume);
+}
+
+//Check if a graphical audio mixer is installed
+bool LOS::hasMixerUtility(){
+  return QFile::exists(LOS::AppPrefix() + "bin/pavucontrol");
+}
+
+//Launch the graphical audio mixer utility
+void LOS::startMixerUtility(){
+  QProcess::startDetached(LOS::AppPrefix() + "bin/pavucontrol");
+}
+
+//Check for user system permission (shutdown/restart)
+bool LOS::userHasShutdownAccess(){
+  return true; //not implemented yet
+}
+
+//System Shutdown
+void LOS::systemShutdown(){ //start poweroff sequence
+  QProcess::startDetached("shutdown -h now");
+}
+
+//System Restart
+void LOS::systemRestart(){ //start reboot sequence
+  QProcess::startDetached("shutdown -r now");
+}
+
+//Battery Availability
+bool LOS::hasBattery(){
+  QString my_status = LUtils::getCmdOutput("acpi -b").join("");
+  bool no_battery = my_status.contains("No support");
+  if (no_battery) return false;
+  return true;
+}
+
+//Battery Charge Level
+int LOS::batteryCharge(){ //Returns: percent charge (0-100), anything outside that range is counted as an error
+  QString my_status = LUtils::getCmdOutput("acpi -b").join("");
+  int my_start = my_status.indexOf("%");
+  // get the number right before the % sign
+  int my_end = my_start;
+  my_start--;
+  while ( (my_status[my_start] != ' ') && (my_start > 0) )
+      my_start--;
+  my_start++;
+  int my_charge = my_status.mid(my_start, my_end - my_start).toInt();
+  if ( (my_charge < 0) || (my_charge > 100) ) return -1;
+  return my_charge;
+}
+
+//Battery Charging State
+// Many possible values are returned if the laptop is plugged in
+// these include "Unknown, Full and No support.
+// However, it seems just one status is returned when running
+// on battery and that is "Discharging". So if the value we get
+// is NOT Discharging then we assume the battery is charging.
+bool LOS::batteryIsCharging(){
+  QString my_status = LUtils::getCmdOutput("acpi -b").join("");
+  bool discharging = my_status.contains("Discharging");
+  if (discharging) return false;
+  return true;
+}
+
+//Battery Time Remaining
+int LOS::batterySecondsLeft(){ //Returns: estimated number of seconds remaining
+  return 0; //not implemented yet for Linux
+}
+
+#endif


### PR DESCRIPTION
- use synaptic package manager
- use qt5-configuration-tool (see: http://qt-apps.org/content/show.php/Qt5+Configuration+Tool?content=168066, QT_QPA_PLATTFORMTHEME=qt5ct needs to exported by user)
- use df instead of mount (this ensures only physical devices are shown in lumina-fm and not bind-mounts like schroot (cross-compiling environment) mounts)
- set SysPrefix to /
- add recommends to lxpolkit (lumina does not have one yet, required for .desktop files that use pkexecfor gaining root access, /usr/lib/$(gcc -print-multiarch)/lxpolkit needs to be added to autostart by user)
- add recommends to qt5-configuration-tool
- apply patch that uses LuminaOS-Debian instead of LuminaOS-Linux upon 'dpkg-buildpackage'

TODO: automate lxpolkit, qt5ct stuff, proper shutdown stuff (not working in default Debian configuration) setup

Q: I wonder if we should add a new device type "LVM2" for logical volume manager volumes that are mounted and use a different icon?

You can keep this un-merged, until everything is done, in case you prefer it that way.