### PR TITLE
LuminaOS-Debian #2

### DIFF
--- a/libLumina/LuminaOS-Debian.cpp
+++ b/libLumina/LuminaOS-Debian.cpp
@@ -33,14 +33,16 @@ QStringList LOS::ExternalDevicePaths(){
   //Now check the output
   for(int i=0; i<devs.length(); i++){
     if(devs[i].startsWith("/dev/")){
+      devs[i] = devs[i].simplified();
       QString type = devs[i].section(" on ",0,0);
-        type.remove("/dev/");
+      type.remove("/dev/");
       //Determine the type of hardware device based on the dev node
       if(type.startsWith("sd")){ type = "HDRIVE"; }
       else if(type.startsWith("sr")){ type="DVD"; }
+      else if(type.contains("mapper")){ type="LVM"; }
       else{ type = "UNKNOWN"; }
       //Now put the device in the proper output format
-      devs[i] = type+"::::"+devs[i].section("(",1,1).section(",",0,0)+"::::"+devs[i].section(" on ",1,50).section("(",0,0).simplified();
+      devs[i] = type + "::::" + devs[i].section(" ",1,1) + "::::" + devs[i].section(" ",2,2);
     }else{
       //invalid device - remove it from the list
       devs.removeAt(i);

--- a/libLumina/LuminaOS-Linux.cpp
+++ b/libLumina/LuminaOS-Linux.cpp
@@ -30,14 +30,16 @@ QStringList LOS::ExternalDevicePaths(){
   //Now check the output
   for(int i=0; i<devs.length(); i++){
     if(devs[i].startsWith("/dev/")){
-      QString type = devs[i].section(" on ",0,0);
-        type.remove("/dev/");
+      devs[i] = devs[i].simplified();
+      QString type = devs[i].section(" ",0,0);
+      type.remove("/dev/");
       //Determine the type of hardware device based on the dev node
       if(type.startsWith("sd")){ type = "HDRIVE"; }
       else if(type.startsWith("sr")){ type="DVD"; }
+      else if(type.contains("mapper")){ type="LVM"; }
       else{ type = "UNKNOWN"; }
       //Now put the device in the proper output format
-      devs[i] = type+"::::"+devs[i].section("(",1,1).section(",",0,0)+"::::"+devs[i].section(" on ",1,50).section("(",0,0).simplified();
+      devs[i] = type+"::::"+devs[i].section(" ",4,4)+"::::"+devs[i].section(" ",2,2);
     }else{
       //invalid device - remove it from the list
       devs.removeAt(i);

--- a/lumina-fm/MainUI.cpp
+++ b/lumina-fm/MainUI.cpp
@@ -306,6 +306,7 @@ void MainUI::RebuildDeviceMenu(){
     ui->menuExternal_Devices->addSeparator();
   //Scan for externally mounted devices
   QStringList devs = LOS::ExternalDevicePaths();
+  QString label;
     //Output Format: <type>::::<filesystem>::::<path>  (6/24/14 - version 0.4.0 )
         // <type> = [USB, HDRIVE, SDCARD, DVD, UNKNOWN]
 	
@@ -314,8 +315,13 @@ void MainUI::RebuildDeviceMenu(){
     //Skip hidden mount points (usually only for system usage - not user browsing)
     if(devs[i].section("::::",2,2).section("/",-1).startsWith(".")){ continue; } 
     //Create entry for this device
-    QAction *act = new QAction(devs[i].section("::::",2,2).section("/",-1),this);
-        act->setWhatsThis(devs[i].section("::::",2,2)); //full path to mountpoint
+    if(devs[i].section("::::",2,2).section("/",-1).isEmpty()) {
+      label = "root";
+    } else {
+      label = devs[i].section("::::",2,2).section("/",-1);
+    }
+    label = label + " (type: " + devs[i].section("::::",1,1) + ")";
+    QAction *act = new QAction(label,this);          act->setWhatsThis(devs[i].section("::::",2,2)); //full path to mountpoint
 	act->setToolTip( QString(tr("Filesystem: %1")).arg( devs[i].section("::::",1,1) ) );
 	//Now set the appropriate icon
 	QString type = devs[i].section("::::",0,0);


### PR DESCRIPTION
Changes:
- LuminaOS-Debian: lumina-fm expects type:::filesystem::::path, we now ensure we always provide correct output  (some devices where not accessible)
- LuminaOS-Linux: lumina-fm expects type::::filesystem::::path, but instead we generated type::::read-write-flag::::path+"type"+filesystem, so most devices where not accessible, we now ensure to always provide correct output
- lumina-fm: when entry for / was generated the string became " type filesystem" instead, now the / is no longer deleted, but replaced by "root" (eg: "root type btrfs")
- lumina-fm: string changes for device labels (eg: "root (type: btrfs)")
- LuminaOS-Debian/LuminaOS-Linux: add device-type "LVM" (no different icon (yet) in lumina-fm)