### PR TITLE
LuminaOS-Debian #4

### DIFF
--- a/libLumina/LuminaOS-Debian.cpp
+++ b/libLumina/LuminaOS-Debian.cpp
@@ -13,7 +13,7 @@
 //can't read xbrightness settings - assume invalid until set
 static int screenbrightness = -1;
 
-QString LOS::OSName(){ return "Debian"; }
+QString LOS::OSName(){ return "Debian GNU/Linux"; }
 
 //OS-specific prefix(s)
 QString LOS::AppPrefix(){ return "/usr/"; } //Prefix for applications
@@ -22,7 +22,7 @@ QString LOS::SysPrefix(){ return "/"; } //Prefix for system
 //OS-specific application shortcuts (*.desktop files)
 QString LOS::ControlPanelShortcut(){ return ""; } //system control panel
 QString LOS::AppStoreShortcut(){ return LOS::AppPrefix() + "/share/applications/synaptic.desktop"; } //graphical app/pkg manager
-QString LOS::QtConfigShortcut(){ return LOS::AppPrefix() + "/bin/qtconfig"; } //qtconfig binary (NOT *.desktop file)
+QString LOS::QtConfigShortcut(){ return LOS::AppPrefix() + "/bin/qt5ct"; } //qtconfig binary (NOT *.desktop file)
 
 // ==== ExternalDevicePaths() ====
 QStringList LOS::ExternalDevicePaths(){

--- a/lumina-desktop/LSession.cpp
+++ b/lumina-desktop/LSession.cpp
@@ -144,12 +144,16 @@ void LSession::setupSession(){
 void LSession::launchStartupApps(){
   //First start any system-defined startups, then do user defined
   qDebug() << "Launching startup applications";
-  for(int i=0; i<2; i++){
-    QString startfile;
-    if(i==0){startfile = LOS::LuminaShare()+"startapps"; }
-    else{ startfile = QDir::homePath()+"/.lumina/startapps"; }
-    if(!QFile::exists(startfile)){ continue; } //go to the next
+  QString startfile;
+  if(QFile::exists("/etc/luminaStartapps")) {
+    startfile = "/etc/luminaStartapps";
+  } else if (QFile::exists(QDir::homePath()+"/.lumina/startapps")) {
+    startfile = QDir::homePath()+"/.lumina/startapps";
+  } else if (QFile::exists(LOS::LuminaShare()+"startapps")) {
+    startfile = LOS::LuminaShare()+"startapps";
+  }
 
+  if(!startfile.isEmpty()) {
     QFile file(startfile);
     if( file.open(QIODevice::ReadOnly | QIODevice::Text) ){
       QTextStream in(&file);
@@ -163,6 +167,7 @@ void LSession::launchStartupApps(){
       file.close();
     }
   }
+
   //Now play the login music
   if(sessionsettings->value("PlayStartupAudio",true).toBool()){
     LSession::playAudioFile(LOS::LuminaShare()+"Login.ogg");


### PR DESCRIPTION
- read /etc/luminaStartapps aswell (vendor configuration shouldn't be in /usr/share/)
- change OSName Debian into Debian GNU/Linux
- use qt5ct instead of qtconfig (has been there, but seems to got lost recently)