### PR TITLE
proper initialization of lumina-panel

### DIFF
--- a/lumina-desktop/LPanel.cpp
+++ b/lumina-desktop/LPanel.cpp
@@ -31,9 +31,13 @@ LPanel::LPanel(QSettings *file, int scr, int num, QWidget *parent) : QWidget(){
   qDebug() << " -- Setup Panel";
   this->setContentsMargins(0,0,0,0);
   this->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-  this->setWindowFlags(Qt::Tool | Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint | Qt::WindowDoesNotAcceptFocus);
+  //panels cannot get keyboard focus otherwise it upsets the task manager window detection
+  this->setAttribute(Qt::WA_X11DoNotAcceptFocus);
+  this->setAttribute(Qt::WA_X11NetWmWindowTypeDock);
+  this->setAttribute(Qt::WA_AlwaysShowToolTips);
+  this->setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
 
-  this->setWindowTitle("");
+  this->setWindowTitle("LuminaPanel");
   this->setObjectName("LuminaPanelBackgroundWidget");
   this->setStyleSheet("QToolButton::menu-indicator{ image: none; }");
   panelArea->setObjectName("LuminaPanelColor");
@@ -45,13 +49,10 @@ LPanel::LPanel(QSettings *file, int scr, int num, QWidget *parent) : QWidget(){
   //Set special window flags on the panel for proper usage
   this->show();
   //this->setFocusPolicy(Qt::NoFocus);
-  //panels cannot get keyboard focus otherwise it upsets the task manager window detection
-  this->setAttribute(Qt::WA_X11DoNotAcceptFocus);
-  this->setAttribute(Qt::WA_X11NetWmWindowTypeDock);
-  this->setAttribute(Qt::WA_AlwaysShowToolTips); 
-  LSession::handle()->XCB->SetAsSticky(this->winId());
+  //LSession::handle()->XCB->SetAsSticky(this->winId());
   //LSession::handle()->XCB->SetAsPanel(this->winId());  //make sure this happens after Qt creates the window first
-  
+  LX11::SetAsPanel(this->winId());
+
   QTimer::singleShot(1,this, SLOT(UpdatePanel()) ); //start this in a new thread
   connect(screen, SIGNAL(resized(int)), this, SLOT(UpdatePanel()) ); //in case the screen resolution changes
 }
@@ -137,6 +138,7 @@ void LPanel::UpdatePanel(){
   }
   //With QT5, we need to make sure to reset window properties on occasion
   //LSession::handle()->XCB->SetAsSticky(this->winId()); 
+  //LX11::SetAsPanel(this->winId());
   //First test/update all the window attributes as necessary
   //if(!this->testAttribute(Qt::WA_X11DoNotAcceptFocus)){ this->setAttribute(Qt::WA_X11DoNotAcceptFocus); }
   //if(!this->testAttribute(Qt::WA_X11NetWmWindowTypeDock)){ this->setAttribute(Qt::WA_X11NetWmWindowTypeDock); }


### PR DESCRIPTION
What this fixes when using Lumina with Sawfish:
- Sawfish now sees lumina-panel as stand-alone window, no longer sub-window of desktop
- users are now able to apply window rules on lumina-panel independently of lumina-desktop window
- proper recognition and setup as dock window: maximized window no longer overlap lumina-panel, cycle-windows (window-switcher) now properly ignores lumina-panel, fixed-position applied, fixed-size applied, sticky-viewport / sticky-workspace applied, no more window-border for lumina-panel and logout dialog
- _NET_WM_NAME can be grabbed from low-level functions, or high-level like window-rules
- window-type and other information can now be properly retrieved from low-level functions
- Sawfish-Pager now properly works with Lumina: previously restarting Sawfish a few times would lead into major issues with Sawfish-Pager, now everything is fine.

That's a few.

I also tested this changes with Fluxbox and unsurprisingly I haven't found any issues.