### PR TITLE
add checksum for OpenBSD (this is in fact a copy of the code from freeBSD)

### DIFF
--- a/libLumina/LuminaOS-OpenBSD.cpp
+++ b/libLumina/LuminaOS-OpenBSD.cpp
@@ -192,6 +192,19 @@ int LOS::batterySecondsLeft(){ //Returns: estimated number of seconds remaining
 
 //File Checksums
 QStringList LOS::Checksums(QStringList filepaths){ //Return: checksum of the input file
- return QStringList();
+  //on OpenBSD md5 has the following layout 
+  //>md5 LuminaThemes.o LuminaUtils.o 
+  //MD5 (LuminaThemes.o) = 50006505d9d7e54e5154eeb095555055
+  //MD5 (LuminaUtils.o) = d490878ee8866e55e5af571b98b4d448
+
+  QStringList info = LUtils::getCmdOutput("md5 \""+filepaths.join("\" \"")+"\"");
+  for(int i=0; i<info.length(); i++){
+    if( !info[i].contains(" = ") ){ info.removeAt(i); i--; }
+    else{
+      //Strip out the extra information
+      info[i] = info[i].section(" = ",1,1);
+    }
+  }
+ return info;
 }
 #endif


### PR DESCRIPTION
I've just copy this FreeBSD code and it works perfectly on OpenBSD. 
The last issue to solve is the size of the QMessageBox. Most of the time the file name is truncate and split on 2 lines. 