### PR TITLE
Delete picture: warn user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,16 @@
 global.h
 *.qm
+Makefile
+*.o
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+lumina-config/lumina-config
+lumina-desktop/Lumina-DE
+lumina-fm/lumina-fm
+lumina-info/lumina-info
+lumina-open/lumina-open
+lumina-screenshot/lumina-screenshot
+lumina-search/lumina-search
+libLumina/libLuminaUtils.so.1.0
+

--- a/lumina-fm/MainUI.cpp
+++ b/lumina-fm/MainUI.cpp
@@ -1037,6 +1037,10 @@ void MainUI::removePicture(){
   QString file = getCurrentDir();
   if(!file.endsWith("/")){ file.append("/"); }
   file.append(ui->combo_image_name->currentText());
+  //Verify permanent removal of file/dir
+  if(QMessageBox::Yes != QMessageBox::question(this, tr("Verify Removal"), tr("WARNING: This will permanently delete the file from the system!")+"\n"+tr("Are you sure you want to continue?")+"\n\n"+file, QMessageBox::Yes | QMessageBox::No, QMessageBox::No) ){
+    return; //cancelled
+  }
   if( QFile::remove(file) ){
     int index = ui->combo_image_name->currentIndex();
     ui->combo_image_name->removeItem( index );

--- a/lumina-open/main.cpp
+++ b/lumina-open/main.cpp
@@ -327,7 +327,7 @@ int main(int argc, char **argv){
   //qDebug() << "[lumina-open] Finished Cmd:" << cmd << retcode << p->exitStatus();
   
   //if(retcode!=0 ){
-  if(p->exitStatus() == QProcess::CrashExit){
+  if(p->exitStatus() == QProcess::CrashExit or retcode > 0){
     qDebug() << "[lumina-open] Application Error:" << retcode;
     QString err = QString(p->readAllStandardError());
     if(err.isEmpty()){ err = QString(p->readAllStandardOutput()); }


### PR DESCRIPTION
Just 1 line to have coherence of behaviour between the 2 delete butons. 
In standard mode, lumina-fm warn he user before deleting a file. Thus for picctures, this could be the case too. 
