### PR TITLE
Lumina Debian #7

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,9 @@
 lumina-desktop (0.8.3.440-1nano) unstable; urgency=low
 
   * New git snapshot
+  * add build dependency on libxcb-composite0-dev
+  * add dependency on usbmount (tool for automagic mounting
+    of external devices)
 
  -- Christopher Roy Bratusek <nano@jpberlin.de>  Sat, 28 Mar 2015 18:38:13 +0100
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+lumina-desktop (0.8.3.440-1nano) unstable; urgency=low
+
+  * New git snapshot
+
+ -- Christopher Roy Bratusek <nano@jpberlin.de>  Sat, 28 Mar 2015 18:38:13 +0100
+
 lumina-desktop (0.8.3.427-1nano) unstable; urgency=low
 
   * New git snapshot

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,8 @@ Build-Depends: debhelper (>= 9), qt5-qmake, qtbase5-dev, qtmultimedia5-dev,
                libxcb1-dev, libx11-xcb-dev, libxcb-ewmh-dev, make, g++,
                libx11-dev, libxrender-dev, libxcomposite-dev, libxdamage-dev,
                libxcb-icccm4-dev, libxcb-damage0-dev, libxcb-util0-dev,
-               libqt5x11extras5-dev, qttools5-dev-tools, libxcb-image0-dev
+               libqt5x11extras5-dev, qttools5-dev-tools, libxcb-image0-dev,
+               libxcb-composite0-dev
 Standards-Version: 3.9.5
 Homepage: https://github.com/pcbsd/lumina
 
@@ -16,7 +17,8 @@ Replaces: lumina-core (<< 0.8.3.372)
 Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version}),
          libluminautils1, lumina-config, lumina-fm, oxygen-icon-theme,
          lumina-open, lumina-screenshot, lumina-search, lumina-info,
-         lxpolkit, lumina-data, fluxbox, numlockx, xbacklight, xscreensaver
+         lxpolkit, lumina-data, fluxbox, numlockx, xbacklight, xscreensaver,
+         usbmount
 Recommends: qt5-configuration-tool
 Description: Lightweight Qt5-based desktop environment
  Metapackage depending on all other lumina packages.


### PR DESCRIPTION
- add missing build dependency on libxcb-composite0-dev
- add runtime dependency on usbmount

usbmount is an udev based tool that automagically mounts external devices.