### PR TITLE
Debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,20 +23,24 @@ Description: Lightweight Qt5-based desktop environment
 
 Package: libluminautils1
 Architecture: any
+Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: Library for the lumina desktop environment
  Utility library for the lumina desktop environment
 
 Package: libluminautils-dev
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version})
+Section: libdevel
+Depends: ${misc:Depends}, libluminautils1 (= ${binary:Version})
 Description: Development files for lumina desktop environment
- Files needed to develop plugins or extensions for the lumina desktop environment,
- or using libluminautils1 in projects.
+ Files needed to develop plugins or extensions for the lumina desktop
+ environment, or using libluminautils1 in projects.
 
 Package: libluminautils-dbg
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils-dev (= ${binary:Version})
+Section: debug
+Priority: extra
+Depends: ${misc:Depends}, libluminautils1 (= ${binary:Version})
 Description: Debugging symbols for lumina desktop environment
  Debugging symbols for libluminautils1
 
@@ -45,8 +49,8 @@ Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version})
 Replaces: lumina-core (<< 0.8.3.372)
 Description: Configuration utility for the lumina desktop environment
- lumina-config allows to change various aspects of lumina and fluxbox, like the
- wallpaper beeing used, startup-applications, desktop-menu and more.
+ lumina-config allows one to change various aspects of lumina and fluxbox, like
+ the wallpaper beeing used, startup-applications, desktop-menu and more.
 
 Package: lumina-fm
 Architecture: any
@@ -70,15 +74,15 @@ Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version})
 Replaces: lumina-core (<< 0.8.3.372)
 Description: Screenshot utility for the lumina desktop environment
- Simple screenshot utility that allows to snapshot the whole desktop or a single
- window after a configurable delay.
+ Simple screenshot utility that allows one to snapshot the whole desktop or a
+ single window after a configurable delay.
 
 Package: lumina-search
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version})
 Replaces: lumina-core (<< 0.8.3.372)
 Description: Search utility for the lumina desktop environment
- Simple search utility that allows to search for applications or files and
+ Simple search utility that allows one to search for applications or files and
  directories in the user's HOME directory.
 
 Package: lumina-info
@@ -98,11 +102,12 @@ Description: Display configuration tool for the lumina desktop environment
 
 Package: lumina-data
 Architecture: all
-Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1, lumina-desktop
+Depends: ${misc:Depends}, libluminautils1, lumina-desktop
 Replaces: lumina-core (<< 0.8.3.372)
 Description: Data files for the lumina Desktop environment
- - Lumina Wallpapers
- - Lumina Themes
- - Lumina Translations
- - Lumina Sounds
- - Fallback fluxbox configuration
+ This package provides
+  * Lumina Wallpapers
+  * Lumina Themes
+  * Lumina Translations
+  * Lumina Sounds
+  * Fallback fluxbox configuration

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: x11
 Priority: optional
 Maintainer: Christopher Roy Bratusek <nano@jpberlin.de>
 Build-Depends: debhelper (>= 9), qt5-qmake, qtbase5-dev, qtmultimedia5-dev,
-               libxcb1-dev, libx11-xcb-dev, libxcb-ewmh-dev,
+               libxcb1-dev, libx11-xcb-dev, libxcb-composite0-dev, libxcb-ewmh-dev,
                libx11-dev, libxrender-dev, libxcomposite-dev, libxdamage-dev,
                libxcb-icccm4-dev, libxcb-damage0-dev, libxcb-util0-dev,
                libqt5x11extras5-dev, qttools5-dev-tools, libxcb-image0-dev

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: x11
 Priority: optional
 Maintainer: Christopher Roy Bratusek <nano@jpberlin.de>
 Build-Depends: debhelper (>= 9), qt5-qmake, qtbase5-dev, qtmultimedia5-dev,
-               libxcb1-dev, libx11-xcb-dev, libxcb-ewmh-dev, make, g++,
+               libxcb1-dev, libx11-xcb-dev, libxcb-ewmh-dev,
                libx11-dev, libxrender-dev, libxcomposite-dev, libxdamage-dev,
                libxcb-icccm4-dev, libxcb-damage0-dev, libxcb-util0-dev,
                libqt5x11extras5-dev, qttools5-dev-tools, libxcb-image0-dev
@@ -98,7 +98,7 @@ Description: Display configuration tool for the lumina desktop environment
 
 Package: lumina-data
 Architecture: all
-Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version}), lumina-desktop (= ${binary:Version})
+Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1, lumina-desktop
 Replaces: lumina-core (<< 0.8.3.372)
 Description: Data files for the lumina Desktop environment
  - Lumina Wallpapers

--- a/debian/lumina-desktop.install
+++ b/debian/lumina-desktop.install
@@ -1,2 +1,3 @@
 usr/bin/Lumina-DE
-
+debian/luminaDesktop.conf   /etc
+debian/lumina-qt5ct         /etc

--- a/debian/lumina-desktop.install
+++ b/debian/lumina-desktop.install
@@ -1,3 +1,3 @@
 usr/bin/Lumina-DE
 debian/luminaDesktop.conf   /etc
-debian/lumina-qt5ct         /etc
+debian/lumina-qt5ct         /etc/default

--- a/debian/rules
+++ b/debian/rules
@@ -29,8 +29,8 @@ override_dh_auto_configure:
 	for d in $(QMAKE_EXTRA_DIRS) ; do (cd $$d && /usr/lib/$(DEB_HOST_MULTIARCH)/qt5/bin/qmake $(USER_QMAKE_FLAGS)); done
 
 override_dh_auto_clean:
-	-$(MAKE) distclean
-	-find $(CURDIR) -name *.qm | xargs rm
+	dh_auto_clean
+	-find $(CURDIR) -name *.qm -delete
 	-sed -e 's/LuminaOS-Debian/LuminaOS-Linux/g' -i libLumina/libLumina.pro
 
 override_dh_strip:

--- a/debian/rules
+++ b/debian/rules
@@ -5,11 +5,17 @@ DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
-export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
-export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
+
+QMAKE = /usr/lib/$(DEB_HOST_MULTIARCH)/qt5/bin/qmake
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
-USER_QMAKE_FLAGS = PREFIX=/usr LIBPREFIX=/usr/lib/$(DEB_HOST_MULTIARCH) QT5LIBDIR=/usr/lib/$(DEB_HOST_MULTIARCH)/qt5
+USER_QMAKE_FLAGS = \
+	PREFIX=/usr \
+	LIBPREFIX=/usr/lib/$(DEB_HOST_MULTIARCH) \
+	QT5LIBDIR=/usr/lib/$(DEB_HOST_MULTIARCH)/qt5 \
+	QMAKE_CXXFLAGS="$(CXXFLAGS) $(CPPFLAGS)" \
+	QMAKE_LFLAGS="$(LDFLAGS) -Wl,--as-needed"
+
 QMAKE_EXTRA_DIRS = libLumina \
 	lumina-config \
 	lumina-desktop \
@@ -21,36 +27,32 @@ QMAKE_EXTRA_DIRS = libLumina \
 	lumina-xconfig
 
 %:
-	dh $@
+	dh $@ --parallel
 
 override_dh_auto_configure:
 	sed -e 's/LuminaOS-Linux/LuminaOS-Debian/g' -i libLumina/libLumina.pro
-	/usr/lib/$(DEB_HOST_MULTIARCH)/qt5/bin/qmake $(USER_QMAKE_FLAGS)
-	for d in $(QMAKE_EXTRA_DIRS) ; do (cd $$d && /usr/lib/$(DEB_HOST_MULTIARCH)/qt5/bin/qmake $(USER_QMAKE_FLAGS)); done
+	$(QMAKE) $(USER_QMAKE_FLAGS)
+	for d in $(QMAKE_EXTRA_DIRS) ; do (cd $$d && $(QMAKE) $(USER_QMAKE_FLAGS)); done
 
 override_dh_auto_clean:
 	dh_auto_clean
 	-find $(CURDIR) -name *.qm -delete
 	-sed -e 's/LuminaOS-Debian/LuminaOS-Linux/g' -i libLumina/libLumina.pro
 
-override_dh_strip:
-	dh_strip -a --dbg-package=libluminautils-dbg
-
 override_dh_install:
-	dh_install --fail-missing
-	mkdir $(CURDIR)/debian/lumina-desktop/etc/
-	install -m644 $(CURDIR)/debian/luminaDesktop.conf \
-		$(CURDIR)/debian/lumina-desktop/etc/luminaDesktop.conf
+	dh_install --list-missing
 	echo "/usr/lib/$(DEB_HOST_MULTIARCH)/lxpolkit" > \
 		$(CURDIR)/debian/lumina-desktop/etc/luminaStartapps
 	mv $(CURDIR)/debian/lumina-desktop/usr/bin/Lumina-DE \
 		$(CURDIR)/debian/lumina-desktop/usr/bin/Lumina-DE.real
 	install -m755 $(CURDIR)/debian/Lumina-DE \
 		$(CURDIR)/debian/lumina-desktop/usr/bin/Lumina-DE
-	mkdir -p $(CURDIR)/debian/lumina-desktop/etc/default
-	install -m644 $(CURDIR)/debian/lumina-qt5ct \
-		$(CURDIR)/debian/lumina-desktop/etc/default/lumina-qt5ct
+	# make install / dh_auto_install will automatically strip the library.
+	# This is a work-around to preserve the debug symbols for the debug package.
+	install -m644 libLumina/libLuminaUtils.so.1.0.0 \
+		$(CURDIR)/debian/libluminautils1/usr/lib/$(DEB_HOST_MULTIARCH)
 
-override_dh_auto_install:
-	INSTALL_ROOT=$(CURDIR)/debian/tmp/ $(MAKE) install
-	-rm -rf $(CURDIR)/debian/tmp/usr/etc/
+override_dh_strip:
+	dh_strip -plibluminautils1 --dbg-package=libluminautils-dbg
+	dh_strip --remaining-packages
+


### PR DESCRIPTION
These changes will fix the following packaging related issues:
```
E: lumina-desktop source: depends-on-build-essential-package-without-using-version make [build-depends: make]
E: lumina-desktop source: depends-on-build-essential-package-without-using-version g++ [build-depends: g++]
W: lumina-desktop source: debian-rules-ignores-make-clean-error line 32
E: lumina-desktop source: not-binnmuable-all-depends-any lumina-data -> libluminautils1
E: lumina-desktop source: not-binnmuable-all-depends-any lumina-data -> lumina-desktop

dpkg-gencontrol: warning: package libluminautils1: unused substitution variable ${misc:Pre-Depends}
dpkg-gencontrol: warning: Depends field of package libluminautils-dev: unknown substitution variable ${shlibs:Depends}
dpkg-gencontrol: warning: Depends field of package libluminautils-dbg: unknown substitution variable ${shlibs:Depends}
dpkg-gencontrol: warning: Depends field of package lumina-data: unknown substitution variable ${shlibs:Depends}

W: libluminautils-dbg: wrong-section-according-to-package-name libluminautils-dbg => debug
W: libluminautils-dbg: debug-package-should-be-priority-extra libluminautils-dbg
W: libluminautils-dbg: empty-binary-package

W: libluminautils-dev: extended-description-line-too-long
W: libluminautils-dev: wrong-section-according-to-package-name libluminautils-dev => libdevel

W: lumina-data: possible-unindented-list-in-extended-description

W: lumina-config: spelling-error-in-description allows to allows one to
W: lumina-screenshot: spelling-error-in-description allows to allows one to
W: lumina-search: spelling-error-in-description allows to allows one to
```

I've also removed some unnessecary things from debian/rules and enabled passing the buildflags to qmake.
I'm running Ubuntu 14.04 (64 bit) with g++ version 4.8.2 (Ubuntu 4.8.2-19ubuntu1).

PS: Some warnings appeared during the build (full log: https://gist.github.com/darealshinji/d5597f622ea9a7be2611).
```
g++ -c -g -O2 -fPIE -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -O2 -Wall -W -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_MULTIMEDIA_LIB -DQT_X11EXTRAS_LIB -DQT_WIDGETS_LIB -DQT_NETWORK_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++-64 -I. -I/usr/include -I/usr/include/qt5 -I/usr/include/qt5/QtMultimedia -I/usr/include/qt5/QtX11Extras -I/usr/include/qt5/QtWidgets -I/usr/include/qt5/QtNetwork -I/usr/include/qt5/QtGui -I/usr/include/qt5/QtCore -I. -o LuminaX11.o LuminaX11.cpp
LuminaX11.cpp: In member function 'void LXCB::SetAsPanel(WId)':
LuminaX11.cpp:1171:18: warning: attempt to free a non-heap object 'hints' [-Wfree-nonheap-object]
      free(&hints); //free up hints structure
                  ^

g++ -c -g -O2 -fPIE -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -O2 -Wall -W -D_REENTRANT -fPIE -DQT_NO_DEBUG -DQT_MULTIMEDIA_LIB -DQT_X11EXTRAS_LIB -DQT_WIDGETS_LIB -DQT_NETWORK_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++-64 -I. -I../libLumina -I/usr/include -I/usr/include/qt5 -I/usr/include/qt5/QtMultimedia -I/usr/include/qt5/QtX11Extras -I/usr/include/qt5/QtWidgets -I/usr/include/qt5/QtNetwork -I/usr/include/qt5/QtGui -I/usr/include/qt5/QtCore -I. -I. -o main.o main.cpp
main.cpp:30:6: warning: unused parameter 'context' [-Wunused-parameter]
 void MessageOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg){
      ^

g++ -c -g -O2 -fPIE -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -O2 -Wall -W -D_REENTRANT -fPIE -DQT_NO_DEBUG -DQT_MULTIMEDIA_LIB -DQT_X11EXTRAS_LIB -DQT_WIDGETS_LIB -DQT_NETWORK_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++-64 -I. -I../libLumina -I/usr/include -I/usr/include/qt5 -I/usr/include/qt5/QtMultimedia -I/usr/include/qt5/QtX11Extras -I/usr/include/qt5/QtWidgets -I/usr/include/qt5/QtNetwork -I/usr/include/qt5/QtGui -I/usr/include/qt5/QtCore -I. -I. -o LSysTray.o panel-plugins/systemtray/LSysTray.cpp
panel-plugins/systemtray/LSysTray.cpp: In member function 'void LSysTray::checkAll()':
panel-plugins/systemtray/LSysTray.cpp:172:8: warning: variable 'listChanged' set but not used [-Wunused-but-set-variable]
   bool listChanged = false;
        ^
```
