### PR TITLE
lumina-fm show separated number of folders and files in status bar

### DIFF
--- a/lumina-fm/BackgroundWorker.cpp
+++ b/lumina-fm/BackgroundWorker.cpp
@@ -88,14 +88,19 @@ void BackgroundWorker::startDirChecks(QString path){
 }
 
 
-void BackgroundWorker::createStatusBarMsg(QFileInfoList fileList, QString path, QString message){
+void BackgroundWorker::createStatusBarMsg(QFileInfoList fileList, QString path, QString messageFolders, QString messageFiles){
+
   //collect some statistics of dir and display them in statusbar
   //Get the total size of the items
   double totalSizes = 0;
+  int numberFolders = 0;
+  int numberFiles = 0;
   for(int i=0; i<fileList.length(); i++){
     if(!fileList[i].isDir()){
+      numberFiles += 1;
       totalSizes += fileList[i].size(); //in Bytes
     }
+    else { numberFolders += 1; }
   }
   //Convert the size into display units
   static QStringList units = QStringList() << tr("B") << tr("KB") << tr("MB") << tr("GB") << tr("TB");
@@ -105,7 +110,8 @@ void BackgroundWorker::createStatusBarMsg(QFileInfoList fileList, QString path, 
     totalSizes = totalSizes/1024;
   }
   //Assemble the message
-  QString msgStatusBar = QString(tr("%1: %2")).arg(message).arg(fileList.length());
+  QString msgStatusBar = QString(tr("%1: %2 / %3: %4")).arg(messageFolders).arg(numberFolders).arg(messageFiles).arg(numberFiles);
+
   if(totalSizes > 0){
     totalSizes = qRound(totalSizes*100)/100.0; //round to 2 decimel places
     msgStatusBar += "    "+QString(tr("Total size: %1 %2")).arg(QString::number(totalSizes), units[cunit]);

--- a/lumina-fm/BackgroundWorker.cpp
+++ b/lumina-fm/BackgroundWorker.cpp
@@ -97,10 +97,10 @@ void BackgroundWorker::createStatusBarMsg(QFileInfoList fileList, QString path, 
   int numberFiles = 0;
   for(int i=0; i<fileList.length(); i++){
     if(!fileList[i].isDir()){
-      numberFiles += 1;
+      numberFiles++;
       totalSizes += fileList[i].size(); //in Bytes
     }
-    else { numberFolders += 1; }
+    else { numberFolders++; }
   }
   //Convert the size into display units
   static QStringList units = QStringList() << tr("B") << tr("KB") << tr("MB") << tr("GB") << tr("TB");

--- a/lumina-fm/BackgroundWorker.h
+++ b/lumina-fm/BackgroundWorker.h
@@ -34,7 +34,7 @@ public slots:
 	//Kickoff processes with these slots
         // and then listen for the appropriate signals when finished
 	void startDirChecks(QString path);
-	void createStatusBarMsg(QFileInfoList fileList, QString path, QString message);
+	void createStatusBarMsg(QFileInfoList fileList, QString path, QString messageFolders, QString messageFiles);
 
 signals:
 	void ImagesAvailable(QStringList files);

--- a/lumina-fm/MainUI.cpp
+++ b/lumina-fm/MainUI.cpp
@@ -219,7 +219,7 @@ void MainUI::setupConnections(){
   connect(worker, SIGNAL(SnapshotsAvailable(QString, QStringList)), this, SLOT(AvailableBackups(QString, QStringList)) );
 
   //Background worker class for statusbar
-  connect(this, SIGNAL(Si_AdaptStatusBar(QFileInfoList, QString, QString)), worker, SLOT(createStatusBarMsg(QFileInfoList, QString, QString)) );
+  connect(this, SIGNAL(Si_AdaptStatusBar(QFileInfoList, QString, QString, QString)), worker, SLOT(createStatusBarMsg(QFileInfoList, QString, QString, QString)) );
   connect(worker, SIGNAL(Si_DisplayStatusBar(QString)), this, SLOT(DisplayStatusBar(QString)) );
 	
   //Action buttons on browser page
@@ -850,7 +850,7 @@ void MainUI::currentDirectoryLoaded(){
   ui->tool_goToRestore->setVisible(false);
   ui->tool_goToImages->setVisible(false);
   emit DirChanged(getCurrentDir());
-  emit Si_AdaptStatusBar(fsmod->rootDirectory().entryInfoList(), getCurrentDir(), tr("Items"));
+  emit Si_AdaptStatusBar(fsmod->rootDirectory().entryInfoList(), getCurrentDir(), tr("Folders"), tr("Files"));
   ItemSelectionChanged();
 }
 
@@ -983,9 +983,9 @@ void MainUI::ItemSelectionChanged(){
   QFileInfoList sel = getSelectedItems();
   //display info related to files selected. 
   //TO CHECK: impact if filesystem is very slow
-  if(sel.size()>0){ emit Si_AdaptStatusBar(sel, "", tr("Items selected")); }
-  else{ emit Si_AdaptStatusBar(fsmod->rootDirectory().entryInfoList(), getCurrentDir(), tr("Items")); }	
-  
+  if(sel.size()>0){ emit Si_AdaptStatusBar(sel, "", tr("Selected Folders"), tr("Files"));}
+  else{ emit Si_AdaptStatusBar(fsmod->rootDirectory().entryInfoList(), getCurrentDir(), tr("Folders"), tr("Files")); }
+
   ui->tool_act_run->setEnabled(sel.length()==1);
   ui->tool_act_runwith->setEnabled(sel.length()==1);
   ui->tool_act_rm->setEnabled(!sel.isEmpty() && isUserWritable);

--- a/lumina-fm/MainUI.h
+++ b/lumina-fm/MainUI.h
@@ -225,7 +225,7 @@ private slots:
 
 signals:
 	void DirChanged(QString path);
-	void Si_AdaptStatusBar(QFileInfoList fileList, QString path, QString message); 
+	void Si_AdaptStatusBar(QFileInfoList fileList, QString path, QString messageFolders, QString messageFiles);
 
 protected:
 	void resizeEvent(QResizeEvent*);


### PR DESCRIPTION
Lumina-FM's statusbar shows the number of folders and files combined as "Items: NNN". This minor change splits that.

New string examples:
* No Selection: "Folders NN / Files NN"
* Selection: "Selected Folders NN / Files NN"

