### PR TITLE
Lumina panel date/time formats

### DIFF
--- a/lumina-config/mainUI.cpp
+++ b/lumina-config/mainUI.cpp
@@ -237,6 +237,7 @@ void MainUI::setupConnections(){
   connect(ui->line_session_time, SIGNAL(textChanged(QString)), this, SLOT(sessionLoadTimeSample()) );
   connect(ui->line_session_date, SIGNAL(textChanged(QString)), this, SLOT(sessionLoadDateSample()) );
   connect(ui->combo_session_timezone, SIGNAL(currentIndexChanged(int)), this, SLOT(sessionoptchanged()) );
+  connect(ui->combo_session_datetimeorder, SIGNAL(currentIndexChanged(int)), this, SLOT(sessionoptchanged()) );
 }
 
 void MainUI::setupMenus(){
@@ -274,6 +275,13 @@ void MainUI::setupMenus(){
   for(int i=0; i<fbstyles.length(); i++){
     ui->combo_session_wtheme->addItem(fbstyles[i], fbdir.absoluteFilePath(fbstyles[i]));
   }
+
+  //Display formats for panel clock
+  ui->combo_session_datetimeorder->clear();
+  ui->combo_session_datetimeorder->addItem( tr("Time (Date as tooltip)"), "timeonly");
+  ui->combo_session_datetimeorder->addItem( tr("Date (Time as tooltip)"), "dateonly");
+  ui->combo_session_datetimeorder->addItem( tr("Time first then Date"), "timedate");
+  ui->combo_session_datetimeorder->addItem( tr("Date first then Time"), "datetime");
 
   //Available Time zones
   ui->combo_session_timezone->clear();
@@ -1813,11 +1821,13 @@ void MainUI::loadSessionSettings(){
   ui->push_session_setUserIcon->setIcon( LXDG::findIcon(QDir::homePath()+"/.loginIcon.png", "user-identity") );
   ui->line_session_time->setText( sessionsettings->value("TimeFormat","").toString() );
   ui->line_session_date->setText( sessionsettings->value("DateFormat","").toString() );
+  index = ui->combo_session_datetimeorder->findData( sessionsettings->value("DateTimeOrder").toString() );
+  ui->combo_session_datetimeorder->setCurrentIndex(index);
   if( !sessionsettings->value("CustomTimeZone", false).toBool() ){
     //System Time selected
     ui->combo_session_timezone->setCurrentIndex(0);
   }else{
-    int index = ui->combo_session_timezone->findData( sessionsettings->value("TimeZoneByteCode",QByteArray()).toByteArray() );
+    index = ui->combo_session_timezone->findData( sessionsettings->value("TimeZoneByteCode",QByteArray()).toByteArray() );
     if(index>0){ ui->combo_session_timezone->setCurrentIndex(index); }
     else{ ui->combo_session_timezone->setCurrentIndex(0); }
   }
@@ -1913,6 +1923,7 @@ void MainUI::saveSessionSettings(){
   sessionsettings->setValue("PlayLogoutAudio", ui->check_session_playlogoutaudio->isChecked());
   sessionsettings->setValue("TimeFormat", ui->line_session_time->text());
   sessionsettings->setValue("DateFormat", ui->line_session_date->text());
+  sessionsettings->setValue("DateTimeOrder", ui->combo_session_datetimeorder->currentData().toString());
   if( ui->combo_session_timezone->currentIndex()==0){
     //System Time selected
     sessionsettings->setValue("CustomTimeZone", false);

--- a/lumina-config/mainUI.ui
+++ b/lumina-config/mainUI.ui
@@ -602,8 +602,8 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>233</width>
-                 <height>150</height>
+                 <width>263</width>
+                 <height>178</height>
                 </rect>
                </property>
                <attribute name="label">
@@ -701,7 +701,7 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>197</width>
+                 <width>198</width>
                  <height>117</height>
                 </rect>
                </property>
@@ -799,8 +799,8 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>233</width>
-                 <height>150</height>
+                 <width>263</width>
+                 <height>178</height>
                 </rect>
                </property>
                <attribute name="label">
@@ -898,7 +898,7 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>197</width>
+                 <width>198</width>
                  <height>117</height>
                 </rect>
                </property>
@@ -1467,19 +1467,6 @@
             <string>General Options</string>
            </attribute>
            <layout class="QGridLayout" name="gridLayout">
-            <item row="5" column="0">
-             <spacer name="verticalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>128</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
             <item row="0" column="0">
              <layout class="QVBoxLayout" name="verticalLayout_4">
               <item>
@@ -1535,7 +1522,62 @@
               </item>
              </layout>
             </item>
-            <item row="0" column="1">
+            <item row="6" column="0" colspan="2">
+             <widget class="QGroupBox" name="groupBox_2">
+              <property name="font">
+               <font>
+                <weight>50</weight>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="title">
+               <string>Reset Desktop Settings</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_20">
+               <item>
+                <spacer name="horizontalSpacer_18">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QPushButton" name="push_session_resetSysDefaults">
+                 <property name="text">
+                  <string>Return to system defaults</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="push_session_resetLuminaDefaults">
+                 <property name="text">
+                  <string>Return to Lumina defaults</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_17">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="0" column="1" rowspan="2">
              <layout class="QFormLayout" name="formLayout_3">
               <property name="fieldGrowthPolicy">
                <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -1654,62 +1696,30 @@
                 </property>
                </widget>
               </item>
+              <item row="5" column="1">
+               <widget class="QComboBox" name="combo_session_datetimeorder"/>
+              </item>
+              <item row="5" column="0">
+               <widget class="QLabel" name="label_27">
+                <property name="text">
+                 <string>Display Format</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </item>
-            <item row="6" column="0" colspan="2">
-             <widget class="QGroupBox" name="groupBox_2">
-              <property name="font">
-               <font>
-                <weight>50</weight>
-                <bold>false</bold>
-               </font>
+            <item row="1" column="0">
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
               </property>
-              <property name="title">
-               <string>Reset Desktop Settings</string>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>128</height>
+               </size>
               </property>
-              <layout class="QHBoxLayout" name="horizontalLayout_20">
-               <item>
-                <spacer name="horizontalSpacer_18">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QPushButton" name="push_session_resetSysDefaults">
-                 <property name="text">
-                  <string>Return to system defaults</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="push_session_resetLuminaDefaults">
-                 <property name="text">
-                  <string>Return to Lumina defaults</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer_17">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </widget>
+             </spacer>
             </item>
            </layout>
           </widget>
@@ -1791,8 +1801,8 @@
                    <rect>
                     <x>0</x>
                     <y>0</y>
-                    <width>128</width>
-                    <height>28</height>
+                    <width>510</width>
+                    <height>107</height>
                    </rect>
                   </property>
                   <property name="sizePolicy">

--- a/lumina-desktop/panel-plugins/clock/LClock.cpp
+++ b/lumina-desktop/panel-plugins/clock/LClock.cpp
@@ -38,10 +38,22 @@ void LClock::updateTime(){
   if(useTZ){ CT = CT.toTimeZone(TZ); }
   //Now update the display
   QString label;
-  if(deftime){ label = CT.time().toString(Qt::SystemLocaleShortDate) ; }
-  else{ label=CT.toString(timefmt); }
-  if(defdate){ labelWidget->setToolTip(CT.date().toString(Qt::SystemLocaleLongDate)); }
-  else{ labelWidget->setToolTip(CT.toString(datefmt)); }
+  QString timelabel;
+  QString datelabel;
+  if(deftime){ timelabel = CT.time().toString(Qt::SystemLocaleShortDate) ; }
+  else{ timelabel=CT.toString(timefmt); }
+  if(defdate){ datelabel = CT.date().toString(Qt::SystemLocaleLongDate); }
+  else{ datelabel = CT.toString(datefmt); }
+  if(datetimeorder == "dateonly"){
+	  label = datelabel;
+	  labelWidget->setToolTip(timelabel);
+  }else if(datetimeorder == "timedate"){
+	  label = timelabel + " " + datelabel;
+  }else if(datetimeorder == "datetime"){
+	  label = datelabel + " " + timelabel;
+  }else{ label = timelabel;
+         labelWidget->setToolTip(datelabel);
+  }
   if( this->layout()->direction() == QBoxLayout::TopToBottom ){
     //different routine for vertical text (need newlines instead of spaces)
     label.replace(" ","\n");
@@ -54,6 +66,7 @@ void LClock::updateFormats(){
   datefmt = LSession::handle()->sessionSettings()->value("DateFormat","").toString();
   deftime = timefmt.simplified().isEmpty();
   defdate = datefmt.simplified().isEmpty();
+  datetimeorder = LSession::handle()->sessionSettings()->value("DateTimeOrder", "timeonly").toString();
   useTZ = LSession::handle()->sessionSettings()->value("CustomTimeZone",false).toBool();
   if(useTZ){ TZ = QTimeZone( LSession::handle()->sessionSettings()->value("TimeZoneByteCode", QByteArray()).toByteArray() ); }
   

--- a/lumina-desktop/panel-plugins/clock/LClock.h
+++ b/lumina-desktop/panel-plugins/clock/LClock.h
@@ -26,7 +26,7 @@ public:
 private:
 	QTimer *timer;
 	QLabel *labelWidget;
-	QString timefmt, datefmt;
+	QString timefmt, datefmt, datetimeorder;
 	bool deftime, defdate, useTZ;
 	QTimeZone TZ;
 	


### PR DESCRIPTION
Adds a new option for different date/time display formats in lumina-panel:

* timeonly (default): display time, date as tooltip
* dateonly          : display date, time as tooltip
* datetime          : display date first then time
* timedate          : display time first then date

with UI option.