### PR TITLE
Debian: reboot, shutdown and suspend

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+lumina-desktop (0.8.4.556-1nano) unstable; urgency=low
+
+  * New git snapshot
+  * reboot, shutdown and suspend via logind
+
+ -- Christopher Roy Bratusek <nano@jpberlin.de>  Thu, 23 Apr 2015 20:27:23 +0200
+
 lumina-desktop (0.8.4.533-1nano) unstable; urgency=low
 
   * New git snapshot

--- a/libLumina/LuminaOS-Debian.cpp
+++ b/libLumina/LuminaOS-Debian.cpp
@@ -100,7 +100,6 @@ QString info = LUtils::getCmdOutput("amixer get Master").join("").simplified();;
   }
   return out;
 
-
 }
 
 //Set the current volume
@@ -139,27 +138,37 @@ void LOS::startMixerUtility(){
 
 //Check for user system permission (shutdown/restart)
 bool LOS::userHasShutdownAccess(){
-  return true; //not implemented yet
+  QProcess::startDetached("dbus-send --system --print-reply=literal \
+  --type=method_call --dest=org.freedesktop.login1 \
+  /org/freedesktop/login1 org.freedesktop.login1.Manager.CanPowerOff");
 }
 
 //System Shutdown
 void LOS::systemShutdown(){ //start poweroff sequence
-  QProcess::startDetached("shutdown -h now");
+  QProcess::startDetached("dbus-send --system --print-reply \
+  --dest=org.freedesktop.login1 /org/freedesktop/login1 \
+  org.freedesktop.login1.Manager.PowerOff boolean:true");
 }
 
 //System Restart
 void LOS::systemRestart(){ //start reboot sequence
-  QProcess::startDetached("shutdown -r now");
+  QProcess::startDetached("dbus-send --system --print-reply \
+  --dest=org.freedesktop.login1 /org/freedesktop/login1 \
+  org.freedesktop.login1.Manager.Reboot boolean:true");
 }
 
 //Check for suspend support
 bool LOS::systemCanSuspend(){
-  return false;
+  QProcess::startDetached("dbus-send --system --print-reply=literal \
+  --type=method_call --dest=org.freedesktop.login1 \
+  /org/freedesktop/login1 org.freedesktop.login1.Manager.CanSuspend");
 }
 
 //Put the system into the suspend state
 void LOS::systemSuspend(){
-
+  QProcess::startDetached("dbus-send --system --print-reply \
+  --dest=org.freedesktop.login1 /org/freedesktop/login1 \
+  org.freedesktop.login1.Manager.Suspend boolean:true");
 }
 
 //Battery Availability


### PR DESCRIPTION
Make reboot, shutdown and suspend work using logind. This is pretty safe as systemd is the default in Debian now. In theory you could copy the functions over to LuminaOS-Linux, but if someone does not use systemd it won't work.

Also isn't here Hibernate aswell as Suspend on *BSD? I've just been wondering whether that should be added to the logout-dialog aswell, with corresponding functions in LuminaOS-*.

For systemd it would just be CanHibernate/Hibernate instead of for example CanSuspend/Suspend.