### PR TITLE
patches of lumina-fileinfo when the proposed file is not existing or empty

### DIFF
--- a/lumina-fileinfo/dialog.cpp
+++ b/lumina-fileinfo/dialog.cpp
@@ -122,9 +122,11 @@ void Dialog::LoadDesktopFile(QString input)
     exit(1);
   }
   //if proposed file does not exist, than we will create one based on the templates
-  if (!QFile::exists(input)) {
+  QFileInfo info(desktopFileName);
+  if ((info.size() == 0) && (desktopFileName.endsWith(".desktop"))) {
+    QFile::remove(desktopFileName); //for the copy, we need to remove it
     if (desktopType=="link") {
-    copyTemplate("-link");
+      copyTemplate("-link");
     } else {
       copyTemplate("-app");
     }
@@ -132,7 +134,6 @@ void Dialog::LoadDesktopFile(QString input)
   this->setWindowTitle(desktopFileName.section("/",-1));
   ui->tabWidget->setCurrentIndex(0); //always start on the file info tab
   //Now load the file info and put it into the UI
-  QFileInfo info(desktopFileName);
   QString mime = LXDG::findAppMimeForFile(desktopFileName);
   
   QList<QByteArray> fmt = QImageReader::supportedImageFormats();


### PR DESCRIPTION
this patch correct 2 issues with non existing or empty files:
- lumina-fileinfo file (where file is a not existing file) now return expected values
- lumina-fileinfo file.desktop (where file.desktop is an empty or non existing file) now present the correct screen allowing users to enter values of the desktop file

Thanks to last fix, users willing to create a desktop file (via lumina-fm -> new file) in their ~/Desktop folder are able to edit it.