### PR TITLE
Don't try to free(3) a pointer to stack.

### DIFF
--- a/libLumina/LuminaX11.cpp
+++ b/libLumina/LuminaX11.cpp
@@ -1182,8 +1182,6 @@ void LXCB::SetAsPanel(WId win){
     qDebug() << " -- Set no inputs flag";
      xcb_icccm_wm_hints_set_input(&hints, False); //set no input focus
      xcb_icccm_set_wm_hints(QX11Info::connection(), win, &hints); //save hints back to window
-    qDebug() << " -- Free the hints structure";
-     free(&hints); //free up hints structure
   }
   //  - Remove WM_TAKE_FOCUS from the WM_PROTOCOLS for the window
   //  - - Generate the necessary atoms


### PR DESCRIPTION
GCC warning helped to spot a real bug: near line 1185 of
libLumina/LuminaX11.cpp there is a call: `free(&hints);`, - but the
"hints" is allocated on the stack a few lines above. This looks
like a copy-paste error, since other free(&hints) instances look
like sane (unless I've missed something, of course).