### PR TITLE
Improvemnts to Linux compatibility

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -73,6 +73,7 @@ X.org and XCB extensions (possibly the XLib libraries above during the transitio
   libxcomposite-dev
   libxdamage-dev
   libxrender-dev
+  libxcb-image0-dev
  
   These packages are required for running Lumina on Linux
   fluxbox

--- a/lumina-config/lumina-config.pro
+++ b/lumina-config/lumina-config.pro
@@ -47,8 +47,11 @@ isEmpty(QT5LIBDIR) {
  QT5LIBDIR = $$PREFIX/lib/qt5
 }
 
-LRELEASE = $$QT5LIBDIR/bin/lrelease
-
+linux: {
+   LRELEASE = /usr/bin/lrelease
+} else {
+   LRELEASE = $$QT5LIBDIR/bin/lrelease
+}
 
 QMAKE_LIBDIR	= ../libLumina
 DEPENDPATH	+= ../libLumina

--- a/lumina-desktop/lumina-desktop.pro
+++ b/lumina-desktop/lumina-desktop.pro
@@ -22,8 +22,11 @@ isEmpty(QT5LIBDIR) {
  QT5LIBDIR = $$PREFIX/lib/qt5
 }
 
-LRELEASE = $$QT5LIBDIR/bin/lrelease
-
+linux: {
+   LRELEASE = /usr/bin/lrelease
+} else {
+   LRELEASE = $$QT5LIBDIR/bin/lrelease
+}
 
 SOURCES += main.cpp \
 	WMProcess.cpp \

--- a/lumina-fileinfo/lumina-fileinfo.pro
+++ b/lumina-fileinfo/lumina-fileinfo.pro
@@ -32,8 +32,11 @@ isEmpty(QT5LIBDIR) {
  QT5LIBDIR = $$PREFIX/lib/qt5
 }
 
-LRELEASE = $$QT5LIBDIR/bin/lrelease
-
+linux: {
+   LRELEASE = /usr/bin/lrelease
+} else {
+   LRELEASE = $$QT5LIBDIR/bin/lrelease
+}
 
 QMAKE_LIBDIR	= ../libLumina
 DEPENDPATH	+= ../libLumina

--- a/lumina-fm/lumina-fm.pro
+++ b/lumina-fm/lumina-fm.pro
@@ -41,7 +41,11 @@ isEmpty(QT5LIBDIR) {
  QT5LIBDIR = $$PREFIX/lib/qt5
 }
 
-LRELEASE = $$QT5LIBDIR/bin/lrelease
+linux: {
+   LRELEASE = /usr/bin/lrelease
+} else {
+   LRELEASE = $$QT5LIBDIR/bin/lrelease
+}
 
 QMAKE_LIBDIR	= ../libLumina
 DEPENDPATH	+= ../libLumina

--- a/lumina-info/lumina-info.pro
+++ b/lumina-info/lumina-info.pro
@@ -30,7 +30,11 @@ isEmpty(QT5LIBDIR) {
  QT5LIBDIR = $$PREFIX/lib/qt5
 }
 
-LRELEASE = $$QT5LIBDIR/bin/lrelease
+linux: {
+   LRELEASE = /usr/bin/lrelease
+} else {
+   LRELEASE = $$QT5LIBDIR/bin/lrelease
+}
 
 QMAKE_LIBDIR	= ../libLumina
 DEPENDPATH	+= ../libLumina

--- a/lumina-open/lumina-open.pro
+++ b/lumina-open/lumina-open.pro
@@ -29,10 +29,14 @@ QMAKE_LIBDIR	= ../libLumina
 DEPENDPATH	+= ../libLumina
 
 isEmpty(QT5LIBDIR) {
- QT5LIBDIR = $$PREFIX/lib/qt5
+    QT5LIBDIR = $$PREFIX/lib/qt5
 }
 
-LRELEASE = $$QT5LIBDIR/bin/lrelease
+linux: {
+   LRELEASE = /usr/bin/lrelease
+} else {
+   LRELEASE = $$QT5LIBDIR/bin/lrelease
+}
 
 
 TRANSLATIONS =  i18n/lumina-open_af.ts \

--- a/lumina-screenshot/lumina-screenshot.pro
+++ b/lumina-screenshot/lumina-screenshot.pro
@@ -29,7 +29,11 @@ isEmpty(QT5LIBDIR) {
  QT5LIBDIR = $$PREFIX/lib/qt5
 }
 
-LRELEASE = $$QT5LIBDIR/bin/lrelease
+linux: {
+   LRELEASE = /usr/bin/lrelease
+} else {
+   LRELEASE = $$QT5LIBDIR/bin/lrelease
+}
 
 QMAKE_LIBDIR	= ../libLumina
 DEPENDPATH	+= ../libLumina

--- a/lumina-search/lumina-search.pro
+++ b/lumina-search/lumina-search.pro
@@ -34,7 +34,11 @@ isEmpty(QT5LIBDIR) {
  QT5LIBDIR = $$PREFIX/lib/qt5
 }
 
-LRELEASE = $$QT5LIBDIR/bin/lrelease
+linux: {
+   LRELEASE = /usr/bin/lrelease
+} else {
+   LRELEASE = $$QT5LIBDIR/bin/lrelease
+}
 
 
 QMAKE_LIBDIR	= ../libLumina

--- a/lumina-wm-INCOMPLETE/lumina-wm.pro
+++ b/lumina-wm-INCOMPLETE/lumina-wm.pro
@@ -22,8 +22,11 @@ isEmpty(QT5LIBDIR) {
  QT5LIBDIR = $$PREFIX/lib/qt5
 }
 
-LRELEASE = $$QT5LIBDIR/bin/lrelease
-
+linux: {
+   LRELEASE = /usr/bin/lrelease
+} else {
+   LRELEASE = $$QT5LIBDIR/bin/lrelease
+}
 
 SOURCES += main.cpp \
 		WMSession.cpp \

--- a/lumina-xconfig/lumina-xconfig.pro
+++ b/lumina-xconfig/lumina-xconfig.pro
@@ -31,7 +31,11 @@ isEmpty(QT5LIBDIR) {
  QT5LIBDIR = $$PREFIX/lib/qt5
 }
 
-LRELEASE = $$QT5LIBDIR/bin/lrelease
+linux: {
+   LRELEASE = /usr/bin/lrelease
+} else {
+   LRELEASE = $$QT5LIBDIR/bin/lrelease
+}
 
 
 QMAKE_LIBDIR	= ../libLumina


### PR DESCRIPTION
This patch includes two changes:

1. The dependency file has been updated to reflect the packages required
   on Linux to compile and install Lumina.

2. The location of LRELEASE is different on Linux than on PC-BSD. Updated
   the project files to detect when Lumina is built on Linux and use the
   proper location of lrelease. The previous method of detecting the location
   using Qt variables does not always work.