### PR TITLE
Updated DEPENDNECIES file.

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -73,7 +73,8 @@ X.org and XCB extensions (possibly the XLib libraries above during the transitio
   libxcomposite-dev
   libxdamage-dev
   libxrender-dev
- 
+  libxcb-image0-dev
+
   These packages are required for running Lumina on Linux
   fluxbox
   kde-style-oxygen


### PR DESCRIPTION
Updated the DEPENDNECIES file to include the libxcb-image0-dev
package, which is required on Debian/Ubuntu systems for building
Lumina.