### PR TITLE
Very minor clean-up to avoid compiler warnings.

### DIFF
--- a/lumina-desktop/LSession.cpp
+++ b/lumina-desktop/LSession.cpp
@@ -534,10 +534,9 @@ void LSession::systemWindow(){
 //Play System Audio
 void LSession::playAudioFile(QString filepath){
   //Setup the audio output systems for the desktop
-  bool init = false;
   if(DEBUG){ qDebug() << "Play Audio File"; }
   //if(audioThread==0){   qDebug() << " - Initialize audio systems"; audioThread = new QThread(); init = true; }
-  if(mediaObj==0){   qDebug() << " - Initialize media player"; mediaObj = new QMediaPlayer(); init = true;}
+  if(mediaObj==0){   qDebug() << " - Initialize media player"; mediaObj = new QMediaPlayer(); }
   /*if(mediaObj && init){  //in case it errors for some reason
     qDebug() << " -- Move audio objects to separate thread";
     mediaObj->moveToThread(audioThread);

--- a/lumina-desktop/panel-plugins/systemtray/LSysTray.cpp
+++ b/lumina-desktop/panel-plugins/systemtray/LSysTray.cpp
@@ -94,7 +94,6 @@ void LSysTray::checkAll(){
   //Make sure this tray should handle the windows (was not disabled in the backend)
   bool TrayRunning = LSession::handle()->registerVisualTray(this->winId());
   //qDebug() << "System Tray: Check tray apps";
-  bool listChanged = false;
   QList<WId> wins = LSession::handle()->currentTrayApps(this->winId());
   for(int i=0; i<trayIcons.length(); i++){
     int index = wins.indexOf(trayIcons[i]->appID());
@@ -105,7 +104,6 @@ void LSysTray::checkAll(){
       LI->removeWidget(cont);
       delete cont;
       i--; //List size changed
-      listChanged = true;
       //Re-adjust the maximum widget size to account for what is left
       if(this->layout()->direction()==QBoxLayout::LeftToRight){
         this->setMaximumSize( trayIcons.length()*this->height(), 10000);
@@ -144,8 +142,6 @@ void LSysTray::checkAll(){
 	LI->removeWidget(cont);
 	delete cont;
 	continue;
-      }else{
-	listChanged = true;
       }
     LI->update(); //make sure there is no blank space in the layout
   }


### PR DESCRIPTION
On a clean compile of the code I found two compiler warnings, both indicating declarations of unused variables. In both cases I think these variables were used for debugging, originally, and are no longer needed. Their declarations have been removed.