### PR TITLE
Make sure disabled numlock stays off. Updated Linux shutdown command.

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -84,5 +84,5 @@ X.org and XCB extensions (possibly the XLib libraries above during the transitio
   xbacklight  (required for changing screen brightness)
   alsa-utils  (required for adjusting audio volume)
   acpi        (required for monitoring battery life)
-  numlockx    (required for changign state of numlock at login)
+  numlockx    (required for changing state of numlock at login)
   pavucontrol (required for detatched audio mixer)

--- a/libLumina/LuminaOS-Linux.cpp
+++ b/libLumina/LuminaOS-Linux.cpp
@@ -141,7 +141,7 @@ bool LOS::userHasShutdownAccess(){
 
 //System Shutdown
 void LOS::systemShutdown(){ //start poweroff sequence
-  QProcess::startDetached("shutdown -h now");
+  QProcess::startDetached("shutdown -P -h now");
 }
 
 //System Restart

--- a/lumina-desktop/LSession.cpp
+++ b/lumina-desktop/LSession.cpp
@@ -229,6 +229,9 @@ void LSession::launchStartupApps(){
     if(sessionsettings->value("EnableNumlock",false).toBool()){
       QProcess::startDetached("numlockx on");
     }
+    else{
+      QProcess::startDetached("numlockx off");
+    }
   }
     
   //First create the list of all possible locations in order of precedence


### PR DESCRIPTION
This patch primarily fixes two minor issues.
1. When number lock is disabled in the session settings, it should now turn off when Lumina starts.

2. In the Linux portion of libLumina, the shutdown command has been updated.

3. A minor typo was fixed in the dependency list.