### PR TITLE
Debian updates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+lumina-desktop (0.8.5.661-1nano) unstable; urgency=low
+
+  * New git snapshot
+   - add dependency on top
+   - add support for cpu-usage and memory-usage in LuminaOS-Debian
+
+ -- Christopher Roy Bratusek <nano@jpberlin.de>  Fri, 22 May 2015 19:22:32 +0200
+
 lumina-desktop (0.8.5.638-1nano) unstable; urgency=low
 
   * New git snapshot

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version
          lumina-xconfig, lumina-fileinfo, lxpolkit, lumina-data, fluxbox,
          numlockx, xbacklight, xscreensaver, usbmount, alsa-utils, acpi,
          gstreamer1.0-plugins-base, phonon4qt5-backend-gstreamer,
-         pavucontrol
+         pavucontrol, top
 Recommends: qt5-configuration-tool
 Description: Lightweight Qt5-based desktop environment
  Metapackage depending on all other lumina packages.

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version
          lumina-xconfig, lumina-fileinfo, lxpolkit, lumina-data, fluxbox,
          numlockx, xbacklight, xscreensaver, usbmount, alsa-utils, acpi,
          gstreamer1.0-plugins-base, phonon4qt5-backend-gstreamer,
-         pavucontrol, top
+         pavucontrol, procps
 Recommends: qt5-configuration-tool
 Description: Lightweight Qt5-based desktop environment
  Metapackage depending on all other lumina packages.

--- a/libLumina/LuminaUtils.cpp
+++ b/libLumina/LuminaUtils.cpp
@@ -43,6 +43,10 @@ int LUtils::runCmd(QString cmd, QStringList args){
 
 QStringList LUtils::getCmdOutput(QString cmd, QStringList args){
   QProcess proc;
+  QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+  env.insert("LANG", "C");
+  env.insert("LC_MESSAGES", "C");
+  proc.setProcessEnvironment(env);
   proc.setProcessChannelMode(QProcess::MergedChannels);
   if(args.isEmpty()){
     proc.start(cmd);


### PR DESCRIPTION
Update for Debian. SystemMonitor working, compiler warning fix and runtime-dependency on top.

Also I modified LUtils::getCmdOutput to enforce LANG=C, as number formats differ between locales, thus break the SystemMonitor functions.