### PR TITLE
Fixed selecting Linux template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@ How to build from source
 1) Checkout the source repo to your local box (GitHub gives a few methods for this)
 
 2) In a terminal, change to the lumina repo directory (base dir, not one of the sub-projects)
- - (Linux Note) If there is a customized OS template for your particular distro (not the general "Linux" template), you will need to change into the libLumina subdirectory and run the "make-linux-distro.sh" script to modify the project file for the Lumina library before running "qmake" in step 3. Be sure to change back to the base Lumina directory before moving on to step 3.
-Example usage: "./make-linux-distro.sh MYDISTRO" (where there is a LuminaOS-MYDISTRO.cpp template available).
 
 3) Run "qmake" on your local system to turn all the Qt project files (*.pro) into Makefiles
  - NOTE: If any of the Qt project files is modified (either by you or from updating the Lumina source tree), you will need to be sure to repeat this step to place those changes into your local Makefiles (otherwise you may experience strange build failures).
  - NOTE 2: The Qt5 version of qmake is located in /usr/local/lib/qt5/bin/qmake on FreeBSD, other OS's may have slightly different locations or names for qmake (such as qmake-qt5 for example)
  - NOTE 3: You can set a customized install PREFIX, LIBPREFIX, and QT5LIBDIR variables via the qmake command. PREFIX determines the base directory to install Lumina ("/usr/local" by default), LIBPREFIX determines the location to install/use libraries ("PREFIX/lib" by default), and QT5LIBDIR determines the location of the Qt5 libraries ("LIBPREFIX/qt5" by default). The syntax to set these custom values when running qmake is usually: "qmake PREFIX=/some/prefix LIBPREFIX=/some/lib/prefix QT5LIBDIR=/main/qt5/library/dir"
+
+ - (Linux Note) If there is a customized OS template for your particular distro (not the general "Linux" template), you will need to change into the libLumina subdirectory and run the "make-linux-distro.sh" script to modify the project file for the Lumina library after running "qmake" in step 3. Be sure to change back to the base Lumina directory before moving on to step 4.
+Example usage: "cd libLumina && ./make-linux-distro.sh MYDISTRO && cd .." (where there is a LuminaOS-MYDISTRO.cpp template available).
+
 
 4) Run "make" to compile all the Lumina projects (can be done as user)
 

--- a/libLumina/make-linux-distro.sh
+++ b/libLumina/make-linux-distro.sh
@@ -7,5 +7,5 @@
 DISTRO=${1}
 #Only perform the change if a distro-specific file is available
 if [ -r LuminaOS-${DISTRO}.cpp ]; then
-  sed "s/LuminaOS-Linux.cpp/LuminaOS-${DISTRO}/" libLumina.pro
+  sed -i "s/LuminaOS-Linux.cpp/LuminaOS-${DISTRO}.cpp/" Makefile
 fi


### PR DESCRIPTION
The original method for selecting a Linux template appears to only
work under Debian. Fixed typo in make-linux-distro.sh script
and modified README.md file to insure selecting a template happens
in the correct order.