### PR TITLE
Minor change to audio to make volume adjustment more tolerant.

### DIFF
--- a/libLumina/LuminaOS-Debian.cpp
+++ b/libLumina/LuminaOS-Debian.cpp
@@ -106,7 +106,8 @@ QString info = LUtils::getCmdOutput("amixer get Master").join("").simplified();;
 void LOS::setAudioVolume(int percent){
   if(percent<0){percent=0;}
   else if(percent>100){percent=100;}
-  QString info = "amixer -c 0 sset Master,0 " + QString::number(percent) + "%";
+  // QString info = "amixer -c 0 sset Master,0 " + QString::number(percent) + "%";
+  QString info = "amixer set Master " + QString::number(percent) + "%";
   if(!info.isEmpty()){
     //Run Command
     LUtils::runCmd(info);


### PR DESCRIPTION
Made a small adjustment to the way sound is set on Linux to make
it more reliable.
On Linux, sometimes volume can go higher than 100% and this seemed to confuse the existing audio volume handling code. Running "lumina-open -volumeup" would sometimes reduce volume. Opening the volume control could cause the volume to drop by 20%. This commit simplifies the call to amixer which fixes the problem, at least on Debian.