### PR TITLE
Updated DEPENDECIES file and proposed fix for compiling the window manager with GCC 4.

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -81,6 +81,9 @@ X.org and XCB extensions (possibly the XLib libraries above during the transitio
   libxrender-dev
   libxcb-image0-dev
 
+  These additional dependencies are needed to build the window manager:
+  libxcb-screensaver0-dev
+
   These packages are required for running Lumina on Linux
   fluxbox
   kde-style-oxygen

--- a/lumina-wm-INCOMPLETE/LXcbEventFilter.cpp
+++ b/lumina-wm-INCOMPLETE/LXcbEventFilter.cpp
@@ -30,10 +30,21 @@ EventFilter::EventFilter() : QObject(){
 
 void EventFilter::start(){
   QCoreApplication::instance()->installNativeEventFilter(EF);
+  xcb_generic_error_t *status;
+  xcb_connection_t *my_connection;
+  xcb_void_cookie_t window_attributes;
+  const unsigned int *returned;
   //Also ensure it gets root window events
 
-   //Need the "real" root window (not the virtual root which Qt might return
-   if( 0!= xcb_request_check( QX11Info::connection(), xcb_change_window_attributes_checked(QX11Info::connection(), L_XCB::root, XCB_CW_EVENT_MASK, (uint32_t[]){ROOT_EVENT_MASK} ) ) ){
+    //Need the "real" root window (not the virtual root which Qt might return
+   my_connection = QX11Info::connection();
+   returned = (uint32_t *) ROOT_EVENT_MASK;
+   window_attributes = xcb_change_window_attributes_checked(my_connection, L_XCB::root, XCB_CW_EVENT_MASK, returned);
+   status = xcb_request_check(my_connection, window_attributes);
+
+   // if( 0!= xcb_request_check( QX11Info::connection(), xcb_change_window_attributes_checked(QX11Info::connection(), L_XCB::root, XCB_CW_EVENT_MASK, (uint32_t[]){ROOT_EVENT_MASK} ) ) ){
+   if (status)
+   {
      qCritical() << "[ERROR] Unable to setup WM event retrieval. Is another WM running?";
      exit(1);
    }


### PR DESCRIPTION
I tried compiling the Lumina window manager with both Clang and GCC. Clang works fine (as usual), but GCC 4 chokes on line 42 of LXcbEventFilter.cpp, ie this line:

if( 0!= xcb_request_check( QX11Info::connection(), xcb_change_window_attributes_checked(QX11Info::connection(), L_XCB::root, XCB_CW_EVENT_MASK, (uint32_t[]){ROOT_EVENT_MASK} ) ) ){

GCC says there is a temporary variable in there, which usually means GCC is either expecting a variable to be explicitly declared or it is fumbling over a register assignment.... At least that is what I have turned up.

This pull offers a potential solution by breaking that one large line into a series of lines. This compiles for me at any rate using either compiler. Admittedly it's a bit ugly, but I think (long-term) it will be better to have these lines seaprated as it will make debugging easier.