### PR TITLE
Moved window manager specific dependencies into their own file

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -81,9 +81,6 @@ X.org and XCB extensions (possibly the XLib libraries above during the transitio
   libxrender-dev
   libxcb-image0-dev
 
-  These additional dependencies are needed to build the window manager:
-  libxcb-screensaver0-dev
-
   These packages are required for running Lumina on Linux
   fluxbox
   kde-style-oxygen

--- a/lumina-wm-INCOMPLETE/DEPENDENCIES
+++ b/lumina-wm-INCOMPLETE/DEPENDENCIES
@@ -1,0 +1,17 @@
+Most dependencies required to build Lumina are listed in the
+DEPENDENCIES file in the directory above this one. The following
+are dependencies specific to Lumina's window manager.
+
+
+FreeBSD/PC-BSD
+=======================
+
+
+
+
+Linux (Debian/Ubuntu)
+=======================
+
+libxcb-screensaver0-dev
+
+


### PR DESCRIPTION
Moved window manager specific dependencies into their own file in the lumina-wm-INCOMPLETE directory.