### PR TITLE
Add qtdeclarative5-dev as a build-dep

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -80,6 +80,7 @@ X.org and XCB extensions (possibly the XLib libraries above during the transitio
   libxdamage-dev
   libxrender-dev
   libxcb-image0-dev
+  qtdeclarative5-dev
 
   These packages are required for running Lumina on Linux
   fluxbox

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9), qt5-qmake, qtbase5-dev, qtmultimedia5-dev,
                libx11-dev, libxrender-dev, libxcomposite-dev, libxdamage-dev,
                libxcb-icccm4-dev, libxcb-damage0-dev, libxcb-util0-dev,
                libqt5x11extras5-dev, qttools5-dev-tools, libxcb-image0-dev,
-               libxcb-composite0-dev
+               libxcb-composite0-dev, qtdeclarative5-dev
 Standards-Version: 3.9.5
 Homepage: https://github.com/pcbsd/lumina
 


### PR DESCRIPTION
I'm currently working on a debian package for Lumina (https://github.com/vovd/lumina-debian) based on  your debian files.
I will push some PRs if I find any other problems in the debian folder :-)

Cheers,
Valentin.