### PR TITLE
Fix typo in lumina-fm/widgets/DirWidget.ui

### DIFF
--- a/lumina-fm/widgets/DirWidget.ui
+++ b/lumina-fm/widgets/DirWidget.ui
@@ -489,7 +489,7 @@
     <string notr="true"/>
    </property>
    <property name="statusTip">
-    <string>Stopl loading the directory</string>
+    <string>Stop loading the directory</string>
    </property>
   </action>
   <action name="actionClose_Browser">


### PR DESCRIPTION
I found this typo in translation work.

Note: From my understanding, translation deadline of Lumina 0.8.7 is October 23(start build date).