### PR TITLE
Fix lumina-support.desktop file

### DIFF
--- a/lumina-info/lumina-support.desktop
+++ b/lumina-info/lumina-support.desktop
@@ -2,11 +2,7 @@
 Type=Link
 URL=https://webchat.freenode.net/?channels=%23lumina-desktop
 Icon=/usr/local/share/pixmaps/Lumina-DE.png
-Terminal=false
-StartupNotify=true
-Categories=System;
 OnlyShowIn=Lumina
 Name=Community Support
 GenericName=Get Desktop Help
 Comment=Ask for desktop support on the community IRC channel
-


### PR DESCRIPTION
usr/share/applications/lumina-support.desktop: error: key "Terminal" is present in group "Desktop Entry", but the type is "Link" while this key is only valid for type "Application"
usr/share/applications/lumina-support.desktop: error: key "StartupNotify" is present in group "Desktop Entry", but the type is "Link" while this key is only valid for type "Application"
usr/share/applications/lumina-support.desktop: error: key "Categories" is present in group "Desktop Entry", but the type is "Link" while this key is only valid for type "Application"