### PR TITLE
Update Debian packaging scripts

### DIFF
--- a/OS-detect.pri
+++ b/OS-detect.pri
@@ -61,12 +61,6 @@
       LINUX_DISTRO = $$system(lsb_release -si)
     }
     
-    #Now switch through known Linux distro templates
-    equals(LINUX_DISTRO, "Fedora"){
-      equals($${QMAKE_HOST.arch},"amd64"){ L_LIBDIR=/lib64 }
-      else{ L_LIBDIR=/lib }
-    }
-    
   }else{ 
     OS="Unknown"; 
   }

--- a/OS-detect.pri
+++ b/OS-detect.pri
@@ -24,8 +24,8 @@
   INCLUDEPATH = $${PWD}/libLumina $$[QT_INSTALL_HEADERS] $$[QT_INSTALL_PREFIX]
   
   #Setup the default values for build settings (if not explicitly set previously)
-  !defined(PREFIX){ PREFIX=/usr/local }
-  !defined(LIBPREFIX){ LIBPREFIX=$${PREFIX}/lib }
+  isEmpty(PREFIX){ PREFIX=/usr/local }
+  isEmpty(LIBPREFIX){ LIBPREFIX=$${PREFIX}/lib }
   
   #Now go through and setup any known OS build settings
   #  which are different from the defaults
@@ -83,13 +83,13 @@
   INCLUDEPATH +=$${PREFIX}/include
   
   # If the detailed install variables are not set - create them from the general vars
-  !defined(L_BINDIR){ L_BINDIR = $${PREFIX}/bin }
-  !defined(L_LIBDIR){ L_LIBDIR = $${PREFIX}/lib }
-  !defined(L_ETCDIR){ L_ETCDIR = $${PREFIX}/etc }
-  !defined(L_SHAREDIR){ L_SHAREDIR = $${PREFIX}/share }
-  !defined(L_INCLUDEDIR){ L_INCLUDEDIR = $${PREFIX}/include }
-  !defined(L_SESSDIR){ L_SESSDIR = $${L_SHAREDIR}/xsessions }
-  !defined(LRELEASE){ LRELEASE = $$[QT_INSTALL_BINS]/lrelease }
+  isEmpty(L_BINDIR){ L_BINDIR = $${PREFIX}/bin }
+  isEmpty(L_LIBDIR){ L_LIBDIR = $${PREFIX}/lib }
+  isEmpty(L_ETCDIR){ L_ETCDIR = $${PREFIX}/etc }
+  isEmpty(L_SHAREDIR){ L_SHAREDIR = $${PREFIX}/share }
+  isEmpty(L_INCLUDEDIR){ L_INCLUDEDIR = $${PREFIX}/include }
+  isEmpty(L_SESSDIR){ L_SESSDIR = $${L_SHAREDIR}/xsessions }
+  isEmpty(LRELEASE){ LRELEASE = $$[QT_INSTALL_BINS]/lrelease }
   
   !exists(LRELEASE){ NO_I18N=true } #translations unavailable
   #Now convert any of these path variables into defines for C++ usage

--- a/OS-detect.pri
+++ b/OS-detect.pri
@@ -47,7 +47,6 @@
   }else : netbsd-*{
     OS = NetBSD
     LIBS += -L/usr/local/lib -L/usr/lib
-    PREFIX=/usr/local
     LIBPREFIX=/usr/local/lib
     #Use the defaults for everything else
     
@@ -55,7 +54,6 @@
     L_SESSDIR=/usr/share/xsessions
     OS=Linux
     LIBS += -L/usr/local/lib -L/usr/lib -L/lib
-    PREFIX = /usr
     
     exists(/bin/lsb_release){
       LINUX_DISTRO = $$system(lsb_release -si)
@@ -65,7 +63,6 @@
     
     #Now switch through known Linux distro templates
     equals(LINUX_DISTRO, "Fedora"){
-      PREFIX=/usr/local
       equals($${QMAKE_HOST.arch},"amd64"){ L_LIBDIR=/lib64 }
       else{ L_LIBDIR=/lib }
     }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,38 @@
+lumina-desktop (0.9.0.1235-1nano) unstable; urgency=low
+
+  * New git snapshot
+  * update for recent Linux distribution detection changes
+  * simplify rules
+  * add missing dependency on libqt5svg5
+  * install usr/share/applications/lumina-support.desktop
+  * install usr/share/Lumina-DE/quickplugins/quick-sample.qml
+
+ -- Christopher Roy Bratusek <nano@jpberlin.de>  Tue, 01 Mar 2016 18:43:22 +0100
+
+lumina-desktop (0.8.7.1081-1nano) unstable; urgency=low
+
+  * New git snapshot
+
+ -- Christopher Roy Bratusek <nano@jpberlin.de>  Sun, 25 Oct 2015 19:56:42 +0100
+
+lumina-desktop (0.8.7.980-1nano) unstable; urgency=low
+
+  * New git snapshot
+
+ -- Christopher Roy Bratusek <nano@jpberlin.de>  Sat, 26 Sep 2015 10:40:30 +0200
+
+lumina-desktop (0.8.7.959-1nano) unstable; urgency=low
+
+  * New git snapshot
+
+ -- Christopher Roy Bratusek <nano@jpberlin.de>  Tue, 15 Sep 2015 20:42:54 +0200
+
+lumina-desktop (0.8.7.858-1nano) unstable; urgency=low
+
+  * New git snapshot
+
+ -- Christopher Roy Bratusek <nano@jpberlin.de>  Thu, 20 Aug 2015 20:07:40 +0200
+
 lumina-desktop (0.8.7.828-1nano) unstable; urgency=low
 
   * New git snapshot

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+lumina-desktop (0.9.0.1235-2nano) unstable; urgency=low
+
+  * New maintainer build
+  * add -dbgsym packages
+
+ -- Christopher Roy Bratusek <nano@jpberlin.de>  Tue, 01 Mar 2016 21:21:33 +0100
+
 lumina-desktop (0.9.0.1235-1nano) unstable; urgency=low
 
   * New git snapshot

--- a/debian/control
+++ b/debian/control
@@ -43,14 +43,6 @@ Description: Development files for lumina desktop environment
  Files needed to develop plugins or extensions for the lumina desktop
  environment, or using libluminautils1 in projects.
 
-Package: libluminautils-dbg
-Architecture: any
-Section: debug
-Priority: extra
-Depends: ${misc:Depends}, libluminautils1 (= ${binary:Version})
-Description: Debugging symbols for lumina desktop environment
- Debugging symbols for libluminautils1
-
 Package: lumina-config
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version})

--- a/debian/libluminautils-dev.install
+++ b/debian/libluminautils-dev.install
@@ -1,2 +1,2 @@
-usr/lib/libLuminaUtils.so
+usr/lib/*/libLuminaUtils.so
 usr/include/*.h

--- a/debian/libluminautils1.install
+++ b/debian/libluminautils1.install
@@ -1,3 +1,3 @@
-usr/lib/libLuminaUtils.so.1
-usr/lib/libLuminaUtils.so.1.0
-usr/lib/libLuminaUtils.so.1.0.0
+usr/lib/*/libLuminaUtils.so.1
+usr/lib/*/libLuminaUtils.so.1.0
+usr/lib/*/libLuminaUtils.so.1.0.0

--- a/debian/lumina-data.install
+++ b/debian/lumina-data.install
@@ -1,3 +1,4 @@
+usr/share/applications/lumina-support.desktop
 usr/share/pixmaps/Lumina-DE.png
 usr/share/Lumina-DE/colors/
 usr/share/Lumina-DE/themes/
@@ -8,5 +9,6 @@ usr/share/Lumina-DE/Login.ogg
 usr/share/Lumina-DE/Logout.ogg
 usr/share/Lumina-DE/luminaDesktop.conf
 usr/share/Lumina-DE/i18n/lumina-desktop*.qm
+usr/share/Lumina-DE/quickplugins/quick-sample.qml
 usr/share/wallpapers/Lumina-DE/
 usr/share/xsessions/Lumina-DE.desktop 

--- a/debian/rules
+++ b/debian/rules
@@ -6,32 +6,15 @@ include /usr/share/dpkg/default.mk
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
-QMAKE = /usr/lib/$(DEB_HOST_MULTIARCH)/qt5/bin/qmake
-
-USER_QMAKE_FLAGS = \
-	PREFIX=/usr \
-	LIBPREFIX=/usr/lib/$(DEB_HOST_MULTIARCH) \
-	QT5LIBDIR=/usr/lib/$(DEB_HOST_MULTIARCH)/qt5 \
-	QMAKE_CXXFLAGS="$(CXXFLAGS) $(CPPFLAGS)" \
-	QMAKE_LFLAGS="$(LDFLAGS) -Wl,--as-needed"
-
-QMAKE_EXTRA_DIRS = libLumina \
-	lumina-config \
-	lumina-desktop \
-	lumina-fm \
-	lumina-open \
-	lumina-screenshot \
-	lumina-search \
-	lumina-info \
-	lumina-xconfig \
-        lumina-fileinfo
-
 %:
 	dh $@ --parallel
 
 override_dh_auto_configure:
-	$(QMAKE) $(USER_QMAKE_FLAGS)
-	for d in $(QMAKE_EXTRA_DIRS) ; do (cd $$d && $(QMAKE) $(USER_QMAKE_FLAGS)); done
+	/usr/lib/$(DEB_HOST_MULTIARCH)/qt5/bin/qmake \
+		PREFIX=/usr \
+		LIBPREFIX=/usr/lib/$(DEB_HOST_MULTIARCH) \
+		L_LIBDIR=/usr/lib/$(DEB_HOST_MULTIARCH) \
+		L_ETCDIR=/etc
 
 override_dh_auto_clean:
 	dh_auto_clean
@@ -43,13 +26,3 @@ override_dh_install:
 		$(CURDIR)/debian/lumina-desktop/usr/bin/Lumina-DE.real
 	install -m755 $(CURDIR)/debian/Lumina-DE \
 		$(CURDIR)/debian/lumina-desktop/usr/bin/Lumina-DE
-	# make install / dh_auto_install will automatically strip the library.
-	# This is a work-around to preserve the debug symbols for the debug package.
-	install -m755 -d $(CURDIR)/debian/libluminautils1/usr/lib/$(DEB_HOST_MULTIARCH)
-	install -m644 libLumina/libLuminaUtils.so.1.0.0 \
-		$(CURDIR)/debian/libluminautils1/usr/lib/$(DEB_HOST_MULTIARCH)
-
-override_dh_strip:
-	dh_strip -plibluminautils1 --dbg-package=libluminautils-dbg
-	dh_strip --remaining-packages
-

--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,10 @@ override_dh_auto_configure:
 		PREFIX=/usr \
 		LIBPREFIX=/usr/lib/$(DEB_HOST_MULTIARCH) \
 		L_LIBDIR=/usr/lib/$(DEB_HOST_MULTIARCH) \
-		L_ETCDIR=/etc
+		L_ETCDIR=/etc \
+		QMAKE_CXXFLAGS="$(CXXFLAGS) $(CPPFLAGS)" \
+		QMAKE_LFLAGS="$(LDFLAGS) -Wl,--as-needed" \
+		CONFIG+=nostrip
 
 override_dh_auto_clean:
 	dh_auto_clean


### PR DESCRIPTION
Long time no see, so back with updated packaging scripts for Debian.

Changes:
  * update for recent Linux distribution detection changes
  * simplify rules
  * add missing dependency on libqt5svg5
  * install usr/share/applications/lumina-support.desktop
  * install usr/share/Lumina-DE/quickplugins/quick-sample.qml
  * replace libluminutils-dbg by -dbgsym packages (see AutomatedDebugPackages in Debian Wiki)

This pull request also fixes #195 by doing the following:
  * using isEmpty(VAR) instead of !defined(VAR), thus external variables do not get overriden
  * don't forcefully override PREFIX for NetBSD (overridden to default anyway), Linux (general) and Fedora (on Linux /usr/local is the default for non-distribution software aswell)

Additional changes to OS-detect.pri:
  * removed Fedora portion, as Fedora's lumina-desktop.spec build file does set all variables on it's own (you might argue about this one)

I've also/already built binary packages for Debian testing/unstable, you can find them here:

    http://apt.nanolx.org/pool/main/l/lumina-desktop

amd64 and i386 are already available, armhf will folllow soon(tm).