### PR TITLE
Quicksave and Crop Functions

### DIFF
--- a/lumina-screenshot/MainUI.cpp
+++ b/lumina-screenshot/MainUI.cpp
@@ -30,7 +30,7 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI){
   connect(ui->actionquicksave, SIGNAL(triggered()), this, SLOT(quicksave()) );
   connect(ui->actionQuit, SIGNAL(triggered()), this, SLOT(closeApplication()) );
   connect(ui->actionNew, SIGNAL(triggered()), this, SLOT(startScreenshot()) );
-
+  connect(ui->actionEdit, SIGNAL(triggered()), this, SLOT(editScreenshot()) );
 
   QSettings::setPath(QSettings::NativeFormat, QSettings::UserScope, QDir::homePath()+"/.lumina");
   settings = new QSettings("LuminaDE", "lumina-screenshot",this);
@@ -55,7 +55,7 @@ void MainUI::setupIcons(){
   ui->actionquicksave->setIcon( LXDG::findIcon("document-save","") );
   ui->actionQuit->setIcon( LXDG::findIcon("application-exit","") );
   ui->actionNew->setIcon( LXDG::findIcon("camera-web","") );	
-
+  ui->actionEdit->setIcon( LXDG::findIcon("edit-cut","") );
 }
 
 //==============
@@ -78,7 +78,11 @@ void MainUI::quicksave(){
    cpic.save(path, "png");
 }
 
-
+void MainUI::editScreenshot(){
+    QString tmppath = QString("/tmp/screenshot.png");
+    cpic.save(tmppath, "png");
+    QProcess::startDetached("gimp /tmp/screenshot.png ");
+}
 
 void MainUI::startScreenshot(){
   if( !getWindow() ){ return; }

--- a/lumina-screenshot/MainUI.cpp
+++ b/lumina-screenshot/MainUI.cpp
@@ -27,8 +27,10 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI){
 
   //Setup the connections
   connect(ui->actionSave, SIGNAL(triggered()), this, SLOT(saveScreenshot()) );
+  connect(ui->actionquicksave, SIGNAL(triggered()), this, SLOT(quicksave()) );
   connect(ui->actionQuit, SIGNAL(triggered()), this, SLOT(closeApplication()) );
   connect(ui->actionNew, SIGNAL(triggered()), this, SLOT(startScreenshot()) );
+
 
   QSettings::setPath(QSettings::NativeFormat, QSettings::UserScope, QDir::homePath()+"/.lumina");
   settings = new QSettings("LuminaDE", "lumina-screenshot",this);
@@ -49,10 +51,11 @@ MainUI::~MainUI(){}
 
 void MainUI::setupIcons(){
   //Setup the icons
-  this->setWindowIcon( LXDG::findIcon("camera-web","") );
   ui->actionSave->setIcon( LXDG::findIcon("document-save","") );
+  ui->actionquicksave->setIcon( LXDG::findIcon("document-save","") );
   ui->actionQuit->setIcon( LXDG::findIcon("application-exit","") );
   ui->actionNew->setIcon( LXDG::findIcon("camera-web","") );	
+
 }
 
 //==============
@@ -65,6 +68,17 @@ void MainUI::saveScreenshot(){
   cpic.save(filepath, "png");
   ppath = filepath;
 }
+void MainUI::quicksave(){
+    QString savedir = QDir::homePath() + "/Pictures/";
+    QDate date = QDate::currentDate();
+    QString dateString = date.toString();
+    QTime time = QTime::currentTime();
+    QString timeString = time.toString();
+    QString path = savedir + QString("Screenshot-[%1 - %2].png").arg(dateString).arg(timeString);
+   cpic.save(path, "png");
+}
+
+
 
 void MainUI::startScreenshot(){
   if( !getWindow() ){ return; }

--- a/lumina-screenshot/MainUI.cpp
+++ b/lumina-screenshot/MainUI.cpp
@@ -70,12 +70,8 @@ void MainUI::saveScreenshot(){
 }
 void MainUI::quicksave(){
     QString savedir = QDir::homePath() + "/Pictures/";
-    QDate date = QDate::currentDate();
-    QString dateString = date.toString();
-    QTime time = QTime::currentTime();
-    QString timeString = time.toString();
-    QString path = savedir + QString("Screenshot-[%1 - %2].png").arg(dateString).arg(timeString);
-   cpic.save(path, "png");
+    QString path = savedir + QString( "Screenshot-%1.png" ).arg( QDateTime::currentDateTime().toString("yyyy-MM-dd-hh-mm-ss") );
+    cpic.save(path, "png");
 }
 
 void MainUI::editScreenshot(){

--- a/lumina-screenshot/MainUI.cpp
+++ b/lumina-screenshot/MainUI.cpp
@@ -77,7 +77,7 @@ void MainUI::quicksave(){
 void MainUI::editScreenshot(){
     QString tmppath = QString("/tmp/screenshot.png");
     cpic.save(tmppath, "png");
-    QProcess::startDetached("gimp /tmp/screenshot.png ");
+   QProcess::startDetached("lumina-open /tmp/screenshot.png");
 }
 
 void MainUI::startScreenshot(){

--- a/lumina-screenshot/MainUI.h
+++ b/lumina-screenshot/MainUI.h
@@ -51,7 +51,7 @@ private slots:
 	}
 	void saveScreenshot();
 	void quicksave();
-
+        void editScreenshot();
 	void startScreenshot();
 
 

--- a/lumina-screenshot/MainUI.h
+++ b/lumina-screenshot/MainUI.h
@@ -50,7 +50,10 @@ private slots:
 	  this->close();
 	}
 	void saveScreenshot();
+	void quicksave();
+
 	void startScreenshot();
+
 
 	//Utility functions to perform a screenshot
 	bool getWindow(); //set the "cwin" variable as appropriate

--- a/lumina-screenshot/MainUI.ui
+++ b/lumina-screenshot/MainUI.ui
@@ -156,8 +156,10 @@
    </attribute>
    <addaction name="actionQuit"/>
    <addaction name="actionSave"/>
+   <addaction name="actionquicksave"/>
+   <addaction name="actionEdit"/>
    <addaction name="actionNew"/>
-  </widget>
+ </widget>
   <action name="actionSave">
    <property name="text">
     <string>Save</string>
@@ -172,6 +174,21 @@
     <string>Ctrl+S</string>
    </property>
   </action>
+  <action name="actionquicksave">
+   <property name="text">
+    <string>Quick Save</string>
+   </property>
+   <property name="toolTip">
+    <string>Quick Save Screenshot</string>
+   </property>
+   <property name="statusTip">
+    <string>Quick Save Screenshot</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+S</string>
+   </property>
+  </action>
+
   <action name="actionQuit">
    <property name="text">
     <string>Quit</string>
@@ -187,7 +204,7 @@
    <property name="statusTip">
     <string>Take new snapshot</string>
    </property>
-  </action>
+</action>
  </widget>
  <resources/>
  <connections/>

--- a/lumina-screenshot/MainUI.ui
+++ b/lumina-screenshot/MainUI.ui
@@ -188,7 +188,11 @@
     <string>Ctrl+S</string>
    </property>
   </action>
-
+  <action name="actionEdit">
+   <property name="text">
+    <string>Crop</string>
+   </property>
+  </action>
   <action name="actionQuit">
    <property name="text">
     <string>Quit</string>


### PR DESCRIPTION
This adds two additions to lumina-screenshot:

1)Quicksave will skip the file dialog window and save to ~/Pictures/ with the file name of "Screenshot" with the date and time appended.  
2)Saves the current screenshot to /tmp and immediately opens GIMP so the user can crop the image to the exact size they want if they only want a small portion of the capture.