### PR TITLE
mostly housekeeping

### DIFF
--- a/lumina-screenshot/MainUI.cpp
+++ b/lumina-screenshot/MainUI.cpp
@@ -55,7 +55,7 @@ void MainUI::setupIcons(){
   ui->actionquicksave->setIcon( LXDG::findIcon("document-save","") );
   ui->actionQuit->setIcon( LXDG::findIcon("application-exit","") );
   ui->actionNew->setIcon( LXDG::findIcon("camera-web","") );	
-  ui->actionEdit->setIcon( LXDG::findIcon("edit-cut","") );
+  ui->actionEdit->setIcon( LXDG::findIcon("applications-graphics","") );
 }
 
 //==============

--- a/lumina-screenshot/MainUI.ui
+++ b/lumina-screenshot/MainUI.ui
@@ -192,6 +192,9 @@
    <property name="text">
     <string>Edit</string>
    </property>
+   <property name="toolTip">
+    <string>Edit Screenshot</string>
+   </property>
   </action>
   <action name="actionQuit">
    <property name="text">

--- a/lumina-screenshot/MainUI.ui
+++ b/lumina-screenshot/MainUI.ui
@@ -218,7 +218,7 @@
     <string>Snap</string>
    </property>
    <property name="statusTip">
-    <string>Take new snapshot</string>
+    <string>Take new Screenshot</string>
    </property>
 </action>
  </widget>

--- a/lumina-screenshot/MainUI.ui
+++ b/lumina-screenshot/MainUI.ui
@@ -190,7 +190,7 @@
   </action>
   <action name="actionEdit">
    <property name="text">
-    <string>Crop</string>
+    <string>Edit</string>
    </property>
   </action>
   <action name="actionQuit">

--- a/lumina-screenshot/MainUI.ui
+++ b/lumina-screenshot/MainUI.ui
@@ -185,7 +185,7 @@
     <string>Quick Save Screenshot</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+S</string>
+    <string>Ctrl+Shift+S</string>
    </property>
   </action>
   <action name="actionEdit">

--- a/lumina-screenshot/MainUI.ui
+++ b/lumina-screenshot/MainUI.ui
@@ -195,6 +195,9 @@
    <property name="toolTip">
     <string>Edit Screenshot</string>
    </property>
+   <property name="statusTip">
+    <string>Edit Screenshot</string>
+   </property>
   </action>
   <action name="actionQuit">
    <property name="text">

--- a/lumina-screenshot/MainUI.ui
+++ b/lumina-screenshot/MainUI.ui
@@ -198,6 +198,9 @@
    <property name="statusTip">
     <string>Edit Screenshot</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+E</string>
+   </property>
   </action>
   <action name="actionQuit">
    <property name="text">

--- a/lumina-screenshot/MainUI.ui
+++ b/lumina-screenshot/MainUI.ui
@@ -209,6 +209,9 @@
    <property name="statusTip">
     <string>Quit</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+Q</string>
+   </property>
   </action>
   <action name="actionNew">
    <property name="text">


### PR DESCRIPTION
Changed Crop text/icon to Edit. It seemed more appropriate since you have a full range of actions inside an editor beyond cropping.  Also done so in future when cropping functionality is built into utility edit will obviously be for further editing.
Added tooltip and statustip for edit function. 
Fixed an error I introduced by having two actions use the same keyboard shortcut.
