### PR TITLE
reordering toolbar buttons

### DIFF
--- a/lumina-screenshot/MainUI.cpp
+++ b/lumina-screenshot/MainUI.cpp
@@ -16,7 +16,7 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI){
   ppath = QDir::homePath();
   QWidget *spacer = new QWidget();
 	spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-	ui->toolBar->insertWidget(ui->actionNew, spacer);
+	ui->toolBar->insertWidget(ui->actionQuit, spacer);
 	
   setupIcons();
   ui->spin_monitor->setMaximum(QApplication::desktop()->screenCount());

--- a/lumina-screenshot/MainUI.ui
+++ b/lumina-screenshot/MainUI.ui
@@ -155,10 +155,10 @@
     <bool>false</bool>
    </attribute>
    <addaction name="actionNew"/>
-   <addaction name="actionQuit"/>
    <addaction name="actionSave"/>
    <addaction name="actionquicksave"/>
    <addaction name="actionEdit"/>
+   <addaction name="actionQuit"/>
  </widget>
   <action name="actionSave">
    <property name="text">

--- a/lumina-screenshot/MainUI.ui
+++ b/lumina-screenshot/MainUI.ui
@@ -154,11 +154,11 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
+   <addaction name="actionNew"/>
    <addaction name="actionQuit"/>
    <addaction name="actionSave"/>
    <addaction name="actionquicksave"/>
    <addaction name="actionEdit"/>
-   <addaction name="actionNew"/>
  </widget>
   <action name="actionSave">
    <property name="text">


### PR DESCRIPTION
Changing order of toolbar buttons to fit the standard workflow of almost every application's toolbar so it's more intuitive. Left to right: New, Save, Edit, Quit.