### PR TITLE
Initial resize event

### DIFF
--- a/lumina-fm/MainUI.cpp
+++ b/lumina-fm/MainUI.cpp
@@ -30,11 +30,8 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI){
     //syncTimer->setInterval(200); //1/5 second (collect as many signals/slots as necessary
     //syncTimer->setSingleShot(true);
   //Reset the UI to the previously used size (if possible)
-  if(DEBUG){ qDebug() << " - Reset window size"; }
-  int height = settings->value("geometry/height",-1).toInt();
-  if(height>100 && height <= QApplication::desktop()->availableGeometry(this).height()){ this->resize(this->width(), height); }
-  int width = settings->value("geometry/width",-1).toInt();
-  if(width>100 && width <= QApplication::desktop()->availableGeometry(this).width()){ this->resize(width, this->height() ); }
+QSize orig = settings->value("preferences/MainWindowSize", QSize()).toSize();
+  if(!orig.isEmpty() && orig.isValid()){
   //initialize the non-ui widgets
   if(DEBUG){ qDebug() << " - Tab Bar Setup"; }
   tabBar = new QTabBar(this);

--- a/lumina-fm/MainUI.cpp
+++ b/lumina-fm/MainUI.cpp
@@ -32,6 +32,10 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI){
   //Reset the UI to the previously used size (if possible)
 QSize orig = settings->value("preferences/MainWindowSize", QSize()).toSize();
   if(!orig.isEmpty() && orig.isValid()){
+     //Make sure the old size is larger than the default size hint
+    if(orig.width() < this->sizeHint().width()){ orig.setWidth(this->sizeHint().width()); }
+    if(orig.height() < this->sizeHint().height()){ orig.setHeight(this->sizeHint().height()); }    
+ 
   //initialize the non-ui widgets
   if(DEBUG){ qDebug() << " - Tab Bar Setup"; }
   tabBar = new QTabBar(this);

--- a/lumina-fm/MainUI.cpp
+++ b/lumina-fm/MainUI.cpp
@@ -32,10 +32,10 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI){
   //Reset the UI to the previously used size (if possible)
 QSize orig = settings->value("preferences/MainWindowSize", QSize()).toSize();
   if(!orig.isEmpty() && orig.isValid()){
-     //Make sure the old size is larger than the default size hint
+    //Make sure the old size is larger than the default size hint
     if(orig.width() < this->sizeHint().width()){ orig.setWidth(this->sizeHint().width()); }
     if(orig.height() < this->sizeHint().height()){ orig.setHeight(this->sizeHint().height()); }    
- //Also ensure the old size is smaller than the current screen size
+    //Also ensure the old size is smaller than the current screen size
     QSize screen = QApplication::desktop()->availableGeometry(this).size();
     if(orig.width() > screen.width()){ orig.setWidth(screen.width()); }
     if(orig.height() > screen.height()){ orig.setHeight(screen.height()); }

--- a/lumina-fm/MainUI.cpp
+++ b/lumina-fm/MainUI.cpp
@@ -35,7 +35,10 @@ QSize orig = settings->value("preferences/MainWindowSize", QSize()).toSize();
      //Make sure the old size is larger than the default size hint
     if(orig.width() < this->sizeHint().width()){ orig.setWidth(this->sizeHint().width()); }
     if(orig.height() < this->sizeHint().height()){ orig.setHeight(this->sizeHint().height()); }    
- 
+ //Also ensure the old size is smaller than the current screen size
+    QSize screen = QApplication::desktop()->availableGeometry(this).size();
+    if(orig.width() > screen.width()){ orig.setWidth(screen.width()); }
+    if(orig.height() > screen.height()){ orig.setHeight(screen.height()); }
   //initialize the non-ui widgets
   if(DEBUG){ qDebug() << " - Tab Bar Setup"; }
   tabBar = new QTabBar(this);

--- a/lumina-fm/MainUI.cpp
+++ b/lumina-fm/MainUI.cpp
@@ -39,6 +39,8 @@ QSize orig = settings->value("preferences/MainWindowSize", QSize()).toSize();
     QSize screen = QApplication::desktop()->availableGeometry(this).size();
     if(orig.width() > screen.width()){ orig.setWidth(screen.width()); }
     if(orig.height() > screen.height()){ orig.setHeight(screen.height()); }
+    //Now resize the window
+    this->resize(orig);
   //initialize the non-ui widgets
   if(DEBUG){ qDebug() << " - Tab Bar Setup"; }
   tabBar = new QTabBar(this);

--- a/lumina-fm/MainUI.h
+++ b/lumina-fm/MainUI.h
@@ -166,7 +166,11 @@ protected:
 	  emit ClientClosed(this);
 	  QMainWindow::closeEvent(ev);
 	}
-	
+	void resizeEvent(QResizeEvent *ev){
+	  //Save the new size to the settings file for later
+	  settings->setValue("preferences/MainWindowSize", ev->size());
+	  QMainWindow::resizeEvent(ev); //just in case the window needs to see the event too
+	}
 
 };
 

--- a/lumina-fm/MainUI.h
+++ b/lumina-fm/MainUI.h
@@ -162,7 +162,11 @@ signals:
 	void Si_AdaptStatusBar(QFileInfoList fileList, QString path, QString messageFolders, QString messageFiles);
 
 protected:
-	void resizeEvent(QResizeEvent*);
+	void closeEvent(QCloseEvent *ev){
+	  emit ClientClosed(this);
+	  QMainWindow::closeEvent(ev);
+	}
+	
 
 };
 


### PR DESCRIPTION
The original resize function has never worked properly on my system, it has always started Lumina-fm as the same size no matter what I change it to during later use.  Using the initial resize function from the sysadm-ui-qt5 source has fixed this problem on my end.  

Im unsure if I was the only one with this problem or that no one else was reporting it.  