### PR TITLE
removed:  QMainWindow::closeEvent(ev);

### DIFF
--- a/lumina-fm/MainUI.h
+++ b/lumina-fm/MainUI.h
@@ -162,9 +162,6 @@ signals:
 	void Si_AdaptStatusBar(QFileInfoList fileList, QString path, QString messageFolders, QString messageFiles);
 
 protected:
-	void closeEvent(QCloseEvent *ev){
-	  emit ClientClosed(this);
-	}
 	void resizeEvent(QResizeEvent *ev){
 	  //Save the new size to the settings file for later
 	  settings->setValue("preferences/MainWindowSize", ev->size());

--- a/lumina-fm/MainUI.h
+++ b/lumina-fm/MainUI.h
@@ -164,7 +164,6 @@ signals:
 protected:
 	void closeEvent(QCloseEvent *ev){
 	  emit ClientClosed(this);
-	  QMainWindow::closeEvent(ev);
 	}
 	void resizeEvent(QResizeEvent *ev){
 	  //Save the new size to the settings file for later


### PR DESCRIPTION
based on your comment in my last PR regarding this line.  if its not needed, there's no reason for it to be there, so I've removed it to keep things neat and tidy.