### PR TITLE
add 2 options for background image: fit and full

### DIFF
--- a/src-qt5/core-utils/lumina-config/mainUI.cpp
+++ b/src-qt5/core-utils/lumina-config/mainUI.cpp
@@ -268,6 +268,8 @@ void MainUI::setupMenus(){
   //Available Wallpaper layout options
   ui->combo_desk_layout->clear();
   ui->combo_desk_layout->addItem(tr("Automatic"), "stretch");
+  ui->combo_desk_layout->addItem(tr("Fullscreen"), "full");
+  ui->combo_desk_layout->addItem(tr("Fit screen"), "fit");
   ui->combo_desk_layout->addItem(tr("Tile"), "tile");
   ui->combo_desk_layout->addItem(tr("Center"), "center");
   ui->combo_desk_layout->addItem(tr("Top Left"), "topleft");

--- a/src-qt5/core/lumina-desktop/LDesktop.cpp
+++ b/src-qt5/core/lumina-desktop/LDesktop.cpp
@@ -214,7 +214,7 @@ void LDesktop::InitDesktop(){
     connect(QApplication::instance(), SIGNAL(LocaleChanged()), this, SLOT(LocaleChanged()) );
 
   if(DEBUG){ qDebug() << "Create bgWindow"; }
-  bgWindow = new QWidget();
+  bgWindow = new LDesktopBackground();
 	bgWindow->setObjectName("bgWindow");
 	bgWindow->setContextMenuPolicy(Qt::CustomContextMenu);
 	bgWindow->setFocusPolicy(Qt::StrongFocus);
@@ -500,49 +500,8 @@ void LDesktop::UpdateBackground(){
   //qDebug() << " - Set Background to:" << CBG << index << bgL;
   if( (bgFile.toLower()=="default")){ bgFile = LOS::LuminaShare()+"desktop-background.jpg"; }
   //Now set this file as the current background
-  QString style;
   QString format = settings->value(DPREFIX+"background/format","stretch").toString();
-  if(bgFile.startsWith("rgb(")){ style = "QWidget#bgWindow{ border-image: none; background-color: %1;}";
-  }else if( format == "center"){ style = "QWidget#bgWindow{ background: black url(%1); background-position: center; background-repeat: no-repeat; }";
-  }else if( format == "topleft"){ style = "QWidget#bgWindow{ background: black url(%1); background-position: top left; background-repeat: no-repeat; }";
-  }else if( format == "topright"){ style = "QWidget#bgWindow{ background: black url(%1); background-position: top right; background-repeat: no-repeat; }";
-  }else if( format == "bottomleft"){ style = "QWidget#bgWindow{ background: black url(%1); background-position: bottom left; background-repeat: no-repeat; }";
-  }else if( format == "bottomright"){ style = "QWidget#bgWindow{ background: black url(%1); background-position: bottom right; background-repeat: no-repeat; }";
-  }else if( format == "tile"){ style = "QWidget#bgWindow{ background-color: black; border-image:url(%1) repeat;}";
-  }else if( format == "full" || format == "fit") { style = "";
-  }else{ /* STRETCH*/ style = "QWidget#bgWindow{ background-color: black; border-image:url(%1) stretch;}"; }
-  style = style.arg(bgFile);
-  bgWindow->setStyleSheet(style);
-  if(!bgFile.startsWith("rgb(") && (format == "full" || format == "fit")){
-    // Load the background file and scale
-    QPixmap background(bgFile);
-    Qt::AspectRatioMode mode;
-    if (format == "full") {
-      mode = Qt::KeepAspectRatioByExpanding;
-    } else {
-      mode = Qt::KeepAspectRatio;
-    }
-    background = background.scaled(bgWindow->size(), mode);
-    // Put the image at the center (for fit)
-    int dx = 0, dy = 0;
-    if (background.width() < bgWindow->width()) {
-      dx = (bgWindow->width() - background.width()) / 2;
-    }
-    if (background.height() < bgWindow->height()) {
-      dy = (bgWindow->height() - background.height()) / 2;
-    }
-    QPixmap fullBg(bgWindow->size());
-    fullBg.fill(Qt::black);
-    QPainter painter(&fullBg);
-    painter.setBrush(background);
-    painter.setBrushOrigin(dx, dy);
-    painter.drawRect(dx, dy, background.width(), background.height());
-    // Set the background
-    QPalette palette;
-    palette.setBrush(QPalette::Background, fullBg);
-    bgWindow->setPalette(palette);
-  }
-  bgWindow->show();
+  bgWindow->setBackground(bgFile, format);
   //Now reset the timer for the next change (if appropriate)
   if(bgtimer->isActive()){ bgtimer->stop(); }
   if(bgL.length() > 1){

--- a/src-qt5/core/lumina-desktop/LDesktop.h
+++ b/src-qt5/core/lumina-desktop/LDesktop.h
@@ -31,6 +31,7 @@
 #include "LDesktopPluginSpace.h"
 #include "desktop-plugins/LDPlugin.h"
 //#include "desktop-plugins/NewDP.h"
+#include "LDesktopBackground.h"
 
 class LDesktop : public QObject{
 	Q_OBJECT
@@ -67,7 +68,7 @@ private:
 	QStringList oldBGL;
 	QList<LPanel*> PANELS;
 	LDesktopPluginSpace *bgDesktop; //desktop plugin area
-	QWidget *bgWindow; //full screen background
+	LDesktopBackground *bgWindow; //full screen background
 	QMenu *deskMenu, *winMenu;
 	QLabel *workspacelabel;
 	QWidgetAction *wkspaceact;

--- a/src-qt5/core/lumina-desktop/LDesktopBackground.cpp
+++ b/src-qt5/core/lumina-desktop/LDesktopBackground.cpp
@@ -1,0 +1,78 @@
+//===========================================
+//  Lumina-DE source code
+//  Copyright (c) 2016, Henry Hu
+//  Available under the 3-clause BSD license
+//  See the LICENSE file for full details
+//===========================================
+#include "LDesktopBackground.h"
+
+#include <QPainter>
+
+void LDesktopBackground::paintEvent(QPaintEvent *pe) {
+    if (bgPixmap != NULL) {
+        QPainter painter(this);
+        painter.setBrush(*bgPixmap);
+        painter.drawRect(0, 0, width(), height());
+    }
+}
+
+void LDesktopBackground::setBackground(const QString& bgFile, const QString& format) {
+    if (bgPixmap != NULL) delete bgPixmap;
+    bgPixmap = new QPixmap(size());
+
+    if (bgFile.startsWith("rgb(")) {
+        QStringList colors = bgFile.section(")",0,0).section("(",1,1).split(",");
+        QColor color = QColor(colors[0].toInt(), colors[1].toInt(), colors[2].toInt());
+        bgPixmap->fill(color);
+    } else {
+        bgPixmap->fill(Qt::black);
+
+        // Load the background file and scale
+        QPixmap bgImage(bgFile);
+        if (format == "stretch" || format == "full" || format == "fit") {
+            Qt::AspectRatioMode mode;
+            if (format == "stretch") {
+                mode = Qt::IgnoreAspectRatio;
+            } else if (format == "full") {
+                mode = Qt::KeepAspectRatioByExpanding;
+            } else {
+                mode = Qt::KeepAspectRatio;
+            }
+            bgImage = bgImage.scaled(size(), mode);
+        }
+
+        // Calculate the offset
+        int dx = 0, dy = 0;
+        int drawWidth = bgImage.width(), drawHeight = bgImage.height();
+        if (format == "fit" || format == "center" || format == "full") {
+            dx = (width() - bgImage.width()) / 2;
+            dy = (height() - bgImage.height()) / 2;
+        } else if (format == "tile") {
+            drawWidth = width();
+            drawHeight = height();
+        } else {
+            if (format.endsWith("right")) {
+                dx = width() - bgImage.width();
+            }
+            if (format.startsWith("bottom")) {
+                dy = height() - bgImage.height();
+            }
+        }
+
+        // Draw the background image
+        QPainter painter(bgPixmap);
+        painter.setBrush(bgImage);
+        painter.setBrushOrigin(dx, dy);
+        painter.drawRect(dx, dy, drawWidth, drawHeight);
+    }
+    update();
+    show();
+}
+
+LDesktopBackground::LDesktopBackground() : QWidget() {
+    bgPixmap = NULL;
+}
+
+LDesktopBackground::~LDesktopBackground() {
+    if (bgPixmap != NULL) delete bgPixmap;
+}

--- a/src-qt5/core/lumina-desktop/LDesktopBackground.h
+++ b/src-qt5/core/lumina-desktop/LDesktopBackground.h
@@ -1,0 +1,27 @@
+//===========================================
+//  Lumina-DE source code
+//  Copyright (c) 2016, Henry Hu
+//  Available under the 3-clause BSD license
+//  See the LICENSE file for full details
+//===========================================
+#ifndef _LUMINA_DESKTOP_LDESKTOPBACKGROUND_H_
+#define _LUMINA_DESKTOP_LDESKTOPBACKGROUND_H_
+
+#include <QString>
+#include <QWidget>
+#include <QPixmap>
+
+class LDesktopBackground: public QWidget {
+    Q_OBJECT
+public:
+    LDesktopBackground();
+    virtual ~LDesktopBackground();
+
+    virtual void paintEvent(QPaintEvent*);
+    void setBackground(const QString&, const QString&);
+
+private:
+    QPixmap *bgPixmap;
+};
+
+#endif // _LUMINA_DESKTOP_LDESKTOPBACKGROUND_H_

--- a/src-qt5/core/lumina-desktop/lumina-desktop.pro
+++ b/src-qt5/core/lumina-desktop/lumina-desktop.pro
@@ -19,6 +19,7 @@ SOURCES += main.cpp \
 	LXcbEventFilter.cpp \
 	LSession.cpp \
 	LDesktop.cpp \
+	LDesktopBackground.cpp \
 	LDesktopPluginSpace.cpp \
 	LPanel.cpp \
 	LWinInfo.cpp \
@@ -34,6 +35,7 @@ HEADERS  += Globals.h \
 	LXcbEventFilter.h \
 	LSession.h \
 	LDesktop.h \
+	LDesktopBackground.h \
 	LDesktopPluginSpace.h \
 	LPanel.h \
 	LWinInfo.h \


### PR DESCRIPTION
Add 2 new options for scaling the background image: fit and full.
Both options keep the aspect ratio of the background image, unlike the option "Automatic".
Full option will scale the image to cover the window, and the top left part is used.
Fit option will scale the image to fit the window, and put it at the center of the window.
It seems to be hard to use QSS to achieve this, so I used QPainter for this.
PS. There seems to be a bug when changing the options. Please don't merge it now.