### PR TITLE
Skip windows with SKIP_TASKBAR state in task manager

### DIFF
--- a/src-qt5/core/lumina-desktop/panel-plugins/taskmanager/LTaskManagerPlugin.cpp
+++ b/src-qt5/core/lumina-desktop/panel-plugins/taskmanager/LTaskManagerPlugin.cpp
@@ -34,6 +34,18 @@ void LTaskManagerPlugin::UpdateButtons(){
 	
   //Get the current window list
   QList<WId> winlist = LSession::handle()->XCB->WindowList();
+  // Ignore the windows which don't want to be listed
+  for (int i = 0; i < winlist.length(); i++) {
+    QList<LXCB::WINDOWSTATE> states = LSession::handle()->XCB->WM_Get_Window_States(winlist[i]);
+    for (int j = 0; j < states.length(); j++) {
+      if (states[j] == LXCB::S_SKIP_TASKBAR) {
+        // Skip taskbar window
+        winlist.removeAt(i);
+        i--;
+        break;
+      }
+    }
+  }
   //Do not change the status of the previously active window if it just changed to a non-visible window
   //WId activeWin = LSession::handle()->XCB->ActiveWindow();
   //bool skipActive = !winlist.contains(activeWin);


### PR DESCRIPTION
Some windows, like Conky, sets SKIP_TASKBAR states. Those windows want to be removed from the task bar (usually background windows which a task button has no use).
This patch checks and removes those from the task manager.