### PR TITLE
use WM_CHANGE_STATE to minimize window

### DIFF
--- a/src-qt5/core/libLumina/LuminaX11.cpp
+++ b/src-qt5/core/libLumina/LuminaX11.cpp
@@ -682,6 +682,7 @@ void LXCB::MinimizeWindow(WId win){ //request that the window be unmapped/minimi
 	
   //Need to send a client message event for the window so the WM picks it up
   xcb_client_message_event_t event;
+  memset(&event, 0, sizeof(event));
   event.response_type = XCB_CLIENT_MESSAGE;
   event.format = 32;
   event.window = win;


### PR DESCRIPTION
Current, Lumina's task manager minimizes window through changing the _NET_WM_STATE property, setting _NET_WM_STATE_HIDDEN. However, in the EWMH spec (https://specifications.freedesktop.org/wm-spec/wm-spec-1.4.html#idm139915842396784), it says:
> Implementation note: if an Application asks to toggle _NET_WM_STATE_HIDDEN the Window Manager should probably just ignore the request, since _NET_WM_STATE_HIDDEN is a function of some other aspect of the window such as minimization, rather than an independent state. 

Although Fluxbox honors this request, some other window managers, like Compiz and Metacity, follow this advice and ignore the request. As a result, when using those window managers, windows can't be minimized through the task bar.
Traditionally (in libwnck), windows are iconified through calling XIconifyWindow(). Internally, it sends a WM_CHANGE_STATE message, with IconifyState as its data. This patch does similar thing using xcb, which works with both Fluxbox and other WMs.