### PR TITLE
fix for icon name error

### DIFF
--- a/src-qt5/desktop-utils/lumina-screenshot/MainUI.cpp
+++ b/src-qt5/desktop-utils/lumina-screenshot/MainUI.cpp
@@ -66,7 +66,7 @@ void MainUI::setupIcons(){
   ui->push_snap->setIcon( LXDG::findIcon("camera-web","") );
   ui->actionTake_Screenshot->setIcon( LXDG::findIcon("camera-web","") );
   ui->tool_crop->setIcon( LXDG::findIcon("transform-crop","") );
-  ui->tool_resize->setIcon( LXDG::findIcon("transform-scale.png") );
+  ui->tool_resize->setIcon( LXDG::findIcon("transform-scale.png","") );
   //ui->actionEdit->setIcon( LXDG::findIcon("applications-graphics","") );
 }
 

--- a/src-qt5/desktop-utils/lumina-screenshot/MainUI.cpp
+++ b/src-qt5/desktop-utils/lumina-screenshot/MainUI.cpp
@@ -66,7 +66,7 @@ void MainUI::setupIcons(){
   ui->push_snap->setIcon( LXDG::findIcon("camera-web","") );
   ui->actionTake_Screenshot->setIcon( LXDG::findIcon("camera-web","") );
   ui->tool_crop->setIcon( LXDG::findIcon("transform-crop","") );
-  ui->tool_resize->setIcon( LXDG::findIcon("transform-scale.png","") );
+  ui->tool_resize->setIcon( LXDG::findIcon("transform-scale","") );
   //ui->actionEdit->setIcon( LXDG::findIcon("applications-graphics","") );
 }
 


### PR DESCRIPTION
Prior to commit:  
[q5sys@skynet] ~/lumina-master/src-qt5/desktop-utils/lumina-screenshot% lumina-screenshot
Loading Locale: "lumina-screenshot" "en_US" "UTF-8"
Number of XCB screens: 1
Could not find icon: "transform-scale.png" ""

After commit: 
[q5sys@skynet] ~/lumina-master/src-qt5/desktop-utils/lumina-screenshot% lumina-screenshot
Loading Locale: "lumina-screenshot" "en_US" "UTF-8"
Number of XCB screens: 1

